### PR TITLE
Side 385 fix non string types handling in javascript ldk

### DIFF
--- a/controllerGrpcServer.js
+++ b/controllerGrpcServer.js
@@ -52,7 +52,7 @@ class ControllerGRPCServer {
 
       Object.entries(configData)
         .forEach(([key, value]) => {
-          response.getConfigMap().set(key, value);
+          response.getConfigMap().set(key, JSON.stringify(value));
         });
 
       callback(null, response);

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ldk",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "Loop Development Kit",
   "main": "index.js",
   "directories": {

--- a/sensorGrpcHostClient.js
+++ b/sensorGrpcHostClient.js
@@ -36,7 +36,7 @@ class SensorGrpcHostClient {
 
       Object.entries(event.data)
         .forEach(([key, value]) => {
-          request.getDataMap().set(key, value);
+          request.getDataMap().set(key, JSON.stringify(value));
         });
 
       this.client.emitEvent(request, (err, response) => {

--- a/sensorGrpcServer.js
+++ b/sensorGrpcServer.js
@@ -52,7 +52,7 @@ class SensorGRPCServer {
 
       Object.entries(configData)
         .forEach(([key, value]) => {
-          response.getConfigMap().set(key, value);
+          response.getConfigMap().set(key, JSON.stringify(value));
         });
 
       callback(null, response);


### PR DESCRIPTION
The GRPC communication expects all the values transmitted in the maps to be strings.