### PR TITLE
[SIDE-480] Increase type checking strictness and fix errors

### DIFF
--- a/src/brokerGrpcServer.ts
+++ b/src/brokerGrpcServer.ts
@@ -18,7 +18,7 @@ export default class BrokerGrpcServer {
    * BrokerGrpcServer(server);
    */
   constructor(server: grpc.Server) {
-    let connInfoCallback;
+    let connInfoCallback!: (connInf: ConnInfo.AsObject) => void;
     this.connInfoPromise = new Promise((resolve) => {
       connInfoCallback = (connInfo: ConnInfo.AsObject) => {
         resolve(connInfo);

--- a/src/controllerGrpcHostClient.ts
+++ b/src/controllerGrpcHostClient.ts
@@ -13,7 +13,7 @@ const errMissingRequiredValue = new Error('value is required');
  * Class used by the controller implementation to interact with the host process.
  */
 class ControllerGrpcHostClient {
-  private client: ControllerHostClient;
+  private _client: ControllerHostClient | undefined;
 
   /**
    * Establish a connection to the host process.
@@ -265,6 +265,17 @@ class ControllerGrpcHostClient {
         return resolve();
       });
     });
+  }
+
+  private get client(): ControllerHostClient {
+    if (this._client === undefined) {
+      throw new Error('Accessing client before connected');
+    }
+    return this._client;
+  }
+
+  private set client(client) {
+    this._client = client;
   }
 }
 

--- a/src/controllerGrpcServer.ts
+++ b/src/controllerGrpcServer.ts
@@ -93,25 +93,27 @@ class ControllerGrpcServer {
     impl: Controller,
   ): services.grpc.handleUnaryCall<messages.OnEventRequest, messages.Empty> {
     return async ({ request }, callback) => {
-      const event = {
-        data: request
-          .getDataMap()
-          .toObject()
-          .reduce((acc: { [index: string]: string }, [key, value]) => {
-            acc[key] = value;
-            return acc;
-          }, {}),
-        source: {
-          id: request.getSource().getId(),
-          category: categories[request.getSource().getCategory()],
-          name: request.getSource().getName(),
-          author: request.getSource().getAuthor(),
-          organization: request.getSource().getOrganization(),
-          version: request.getSource().getVersion(),
-        },
-      };
-
-      await impl.onEvent(event);
+      const source = request?.getSource();
+      if (request && source) {
+        const event = {
+          data: request
+            .getDataMap()
+            .toObject()
+            .reduce((acc: { [index: string]: string }, [key, value]) => {
+              acc[key] = value;
+              return acc;
+            }, {}),
+          source: {
+            id: source.getId(),
+            category: categories[source.getCategory()],
+            name: source.getName(),
+            author: source.getAuthor(),
+            organization: source.getOrganization(),
+            version: source.getVersion(),
+          },
+        };
+        await impl.onEvent(event);
+      }
 
       const response = new messages.Empty();
       callback(null, response);

--- a/src/healthGrpcServer.ts
+++ b/src/healthGrpcServer.ts
@@ -35,9 +35,9 @@ class HealthGrpcServer {
     call: grpc.ServerUnaryCall<HealthCheckRequest, HealthCheckResponse>,
     callback: grpc.sendUnaryData<HealthCheckResponse>,
   ): void {
-    const reqService = call.request.getService();
+    const reqService = call?.request?.getService();
     const status =
-      this._statusMap[reqService] ||
+      this._statusMap[reqService || 'unknown'] ||
       HealthCheckResponse.ServingStatus.SERVICE_UNKNOWN;
     const msg = new HealthCheckResponse();
     msg.setStatus(status);

--- a/src/logging.ts
+++ b/src/logging.ts
@@ -218,7 +218,7 @@ class Logger {
 
     if (argsEven.length % 2 !== 0) {
       const extra = argsEven.pop();
-      argsEven.push('EXTRA_VALUE_AT_END', extra);
+      argsEven.push('EXTRA_VALUE_AT_END', extra as string);
     }
 
     const fields = argsEven.reduce(

--- a/src/sensorGrpcHostClient.ts
+++ b/src/sensorGrpcHostClient.ts
@@ -11,7 +11,7 @@ const errMissingRequiredValue = new Error('value is required');
  * Class used by the sensor implementation to interact with the host process.
  */
 class SensorGrpcHostClient {
-  private client: services.SensorHostClient;
+  private _client: services.SensorHostClient | undefined;
 
   /**
    * Establish a connection to the host process.
@@ -250,6 +250,17 @@ class SensorGrpcHostClient {
         return resolve();
       });
     });
+  }
+
+  private get client(): services.SensorHostClient {
+    if (this._client === undefined) {
+      throw new Error('Accessing client before connected');
+    }
+    return this._client;
+  }
+
+  private set client(client) {
+    this._client = client;
   }
 }
 

--- a/src/sensorGrpcServer.ts
+++ b/src/sensorGrpcServer.ts
@@ -89,25 +89,27 @@ class SensorGRPCServer {
     impl: Sensor,
   ): grpc.handleUnaryCall<messages.OnEventRequest, messages.Empty> {
     return async ({ request }, callback) => {
-      const event = {
-        data: request
-          .getDataMap()
-          .toObject()
-          .reduce((acc: { [index: string]: string }, [key, value]) => {
-            acc[key] = value;
-            return acc;
-          }, {}),
-        source: {
-          id: request.getSource().getId(),
-          category: categories[request.getSource().getCategory()],
-          name: request.getSource().getName(),
-          author: request.getSource().getAuthor(),
-          organization: request.getSource().getOrganization(),
-          version: request.getSource().getVersion(),
-        },
-      };
-
-      await impl.onEvent(event);
+      const source = request?.getSource();
+      if (request && source) {
+        const event = {
+          data: request
+            .getDataMap()
+            .toObject()
+            .reduce((acc: { [index: string]: string }, [key, value]) => {
+              acc[key] = value;
+              return acc;
+            }, {}),
+          source: {
+            id: source.getId(),
+            category: categories[source.getCategory()],
+            name: source.getName(),
+            author: source.getAuthor(),
+            organization: source.getOrganization(),
+            version: source.getVersion(),
+          },
+        };
+        await impl.onEvent(event);
+      }
 
       const response = new messages.Empty();
       callback(null, response);

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -8,8 +8,7 @@
     "esModuleInterop": true,
     "rootDir": "src",
     "declaration": true,
-    "noImplicitAny": true,
-    "noImplicitReturns": true
+    "strict": true
   },
   "exclude": ["node_modules", "dist", "docs", "scripts"]
 }


### PR DESCRIPTION
This PR:

- Turns on TS' `strict` mode, which:
  - Requires a runtime check if the function may return a `null` or `undefined` value
    **Example:** since `OnEventRequest.getSource(): Source | undefined` may return an `undefined` value, I need to check that its truthy before proceeding.
  - Requires properties either to be explicitly initialized in the constructor, or explicitly includes `undefined`.
    **Example:** since `SensorGrpcHostClient` does not have the `client` property assigned until `connect` has been called complete, I need to explicitly let the `client` property be `undefined` and check when accessing it. Since it's a bit cumbersome to do that every time I access the property I wrapped that check into accessor methods.
- Adds those checks where appropriate to the code.
