### PR TITLE
SIDE-533 Publish LDK to NPM (Part 2)

### DIFF
--- a/.github/workflows/npm.yml
+++ b/.github/workflows/npm.yml
@@ -19,13 +19,14 @@ jobs:
       # Setup .npmrc file to publish to NPM
       - uses: actions/setup-node@v1
         with:
+          check-latest: 'true'
           node-version: '12.x'
-          registry-url: 'https://registry.npmjs.org'
+          registry-url: 'https://registry.npmjs.org/'
       - run: npm set audit false
       - run: npm ci
       - run: npm run build --if-present
       - run: npm publish --access public
         env:
           # `secrets.NPM_TOKEN` references a GitHub Secret configured for this repo or organization,
-          # and is used to authentication the NPM publish command.
+          # and is used to authenticate for the NPM publish command.
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/.npmignore
+++ b/.npmignore
@@ -1,3 +1,21 @@
+# Actual ignores
+.eslintignore
+.eslintrc.js
+.gitattributes
+.github
+.gitignore
+.npmignore
+.nvmrc
+.prettierignore
+.prettierrc
+docs
+docsExtra
+jest.config.js
+tsconfig.json
+typedoc.json
+
+## .gitignore stuff
+
 # npm & yarn
 node_modules/
 .npm
@@ -49,3 +67,4 @@ Thumbs.db:*
 .#*
 *.orig
 *.swp
+

--- a/.npmrc
+++ b/.npmrc
@@ -1,1 +1,0 @@
-save-exact = true

--- a/.npmrc
+++ b/.npmrc
@@ -1,2 +1,2 @@
+registry = https://registry.npmjs.org/
 save-exact = true
-registry = http://registry.npmjs.org/

--- a/.npmrc
+++ b/.npmrc
@@ -1,2 +1,1 @@
-registry = https://registry.npmjs.org/
 save-exact = true

--- a/docs/classes/controllerplugin.html
+++ b/docs/classes/controllerplugin.html
@@ -111,7 +111,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/open-olive/loop-development-kit-node/blob/843e171/src/controllerPlugin.ts#L16">controllerPlugin.ts:16</a></li>
+									<li>Defined in <a href="https://github.com/open-olive/loop-development-kit-node/blob/4a08e2f/src/controllerPlugin.ts#L16">controllerPlugin.ts:16</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -148,7 +148,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/open-olive/loop-development-kit-node/blob/843e171/src/controllerPlugin.ts#L41">controllerPlugin.ts:41</a></li>
+									<li>Defined in <a href="https://github.com/open-olive/loop-development-kit-node/blob/4a08e2f/src/controllerPlugin.ts#L41">controllerPlugin.ts:41</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">

--- a/docs/classes/controllerplugin.html
+++ b/docs/classes/controllerplugin.html
@@ -111,7 +111,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/open-olive/loop-development-kit-node/blob/52d7210/src/controllerPlugin.ts#L16">controllerPlugin.ts:16</a></li>
+									<li>Defined in <a href="https://github.com/open-olive/loop-development-kit-node/blob/fa2b79d/src/controllerPlugin.ts#L16">controllerPlugin.ts:16</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -148,7 +148,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/open-olive/loop-development-kit-node/blob/52d7210/src/controllerPlugin.ts#L41">controllerPlugin.ts:41</a></li>
+									<li>Defined in <a href="https://github.com/open-olive/loop-development-kit-node/blob/fa2b79d/src/controllerPlugin.ts#L41">controllerPlugin.ts:41</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">

--- a/docs/classes/controllerplugin.html
+++ b/docs/classes/controllerplugin.html
@@ -111,7 +111,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/open-olive/loop-development-kit-node/blob/fa2b79d/src/controllerPlugin.ts#L16">controllerPlugin.ts:16</a></li>
+									<li>Defined in <a href="https://github.com/open-olive/loop-development-kit-node/blob/843e171/src/controllerPlugin.ts#L16">controllerPlugin.ts:16</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -148,7 +148,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/open-olive/loop-development-kit-node/blob/fa2b79d/src/controllerPlugin.ts#L41">controllerPlugin.ts:41</a></li>
+									<li>Defined in <a href="https://github.com/open-olive/loop-development-kit-node/blob/843e171/src/controllerPlugin.ts#L41">controllerPlugin.ts:41</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">

--- a/docs/classes/controllerplugin.html
+++ b/docs/classes/controllerplugin.html
@@ -111,7 +111,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/open-olive/loop-development-kit-node/blob/4a08e2f/src/controllerPlugin.ts#L16">controllerPlugin.ts:16</a></li>
+									<li>Defined in <a href="https://github.com/open-olive/loop-development-kit-node/blob/2576fcd/src/controllerPlugin.ts#L16">controllerPlugin.ts:16</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -148,7 +148,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/open-olive/loop-development-kit-node/blob/4a08e2f/src/controllerPlugin.ts#L41">controllerPlugin.ts:41</a></li>
+									<li>Defined in <a href="https://github.com/open-olive/loop-development-kit-node/blob/2576fcd/src/controllerPlugin.ts#L41">controllerPlugin.ts:41</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">

--- a/docs/classes/logger.html
+++ b/docs/classes/logger.html
@@ -116,7 +116,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/open-olive/loop-development-kit-node/blob/52d7210/src/logging.ts#L25">logging.ts:25</a></li>
+									<li>Defined in <a href="https://github.com/open-olive/loop-development-kit-node/blob/fa2b79d/src/logging.ts#L25">logging.ts:25</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -167,7 +167,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/open-olive/loop-development-kit-node/blob/52d7210/src/logging.ts#L112">logging.ts:112</a></li>
+									<li>Defined in <a href="https://github.com/open-olive/loop-development-kit-node/blob/fa2b79d/src/logging.ts#L112">logging.ts:112</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -215,7 +215,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/open-olive/loop-development-kit-node/blob/52d7210/src/logging.ts#L175">logging.ts:175</a></li>
+									<li>Defined in <a href="https://github.com/open-olive/loop-development-kit-node/blob/fa2b79d/src/logging.ts#L175">logging.ts:175</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -263,7 +263,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/open-olive/loop-development-kit-node/blob/52d7210/src/logging.ts#L133">logging.ts:133</a></li>
+									<li>Defined in <a href="https://github.com/open-olive/loop-development-kit-node/blob/fa2b79d/src/logging.ts#L133">logging.ts:133</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -311,7 +311,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/open-olive/loop-development-kit-node/blob/52d7210/src/logging.ts#L91">logging.ts:91</a></li>
+									<li>Defined in <a href="https://github.com/open-olive/loop-development-kit-node/blob/fa2b79d/src/logging.ts#L91">logging.ts:91</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -359,7 +359,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/open-olive/loop-development-kit-node/blob/52d7210/src/logging.ts#L154">logging.ts:154</a></li>
+									<li>Defined in <a href="https://github.com/open-olive/loop-development-kit-node/blob/fa2b79d/src/logging.ts#L154">logging.ts:154</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -407,7 +407,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/open-olive/loop-development-kit-node/blob/52d7210/src/logging.ts#L69">logging.ts:69</a></li>
+									<li>Defined in <a href="https://github.com/open-olive/loop-development-kit-node/blob/fa2b79d/src/logging.ts#L69">logging.ts:69</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">

--- a/docs/classes/logger.html
+++ b/docs/classes/logger.html
@@ -116,7 +116,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/open-olive/loop-development-kit-node/blob/843e171/src/logging.ts#L25">logging.ts:25</a></li>
+									<li>Defined in <a href="https://github.com/open-olive/loop-development-kit-node/blob/4a08e2f/src/logging.ts#L25">logging.ts:25</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -167,7 +167,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/open-olive/loop-development-kit-node/blob/843e171/src/logging.ts#L112">logging.ts:112</a></li>
+									<li>Defined in <a href="https://github.com/open-olive/loop-development-kit-node/blob/4a08e2f/src/logging.ts#L112">logging.ts:112</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -215,7 +215,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/open-olive/loop-development-kit-node/blob/843e171/src/logging.ts#L175">logging.ts:175</a></li>
+									<li>Defined in <a href="https://github.com/open-olive/loop-development-kit-node/blob/4a08e2f/src/logging.ts#L175">logging.ts:175</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -263,7 +263,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/open-olive/loop-development-kit-node/blob/843e171/src/logging.ts#L133">logging.ts:133</a></li>
+									<li>Defined in <a href="https://github.com/open-olive/loop-development-kit-node/blob/4a08e2f/src/logging.ts#L133">logging.ts:133</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -311,7 +311,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/open-olive/loop-development-kit-node/blob/843e171/src/logging.ts#L91">logging.ts:91</a></li>
+									<li>Defined in <a href="https://github.com/open-olive/loop-development-kit-node/blob/4a08e2f/src/logging.ts#L91">logging.ts:91</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -359,7 +359,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/open-olive/loop-development-kit-node/blob/843e171/src/logging.ts#L154">logging.ts:154</a></li>
+									<li>Defined in <a href="https://github.com/open-olive/loop-development-kit-node/blob/4a08e2f/src/logging.ts#L154">logging.ts:154</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -407,7 +407,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/open-olive/loop-development-kit-node/blob/843e171/src/logging.ts#L69">logging.ts:69</a></li>
+									<li>Defined in <a href="https://github.com/open-olive/loop-development-kit-node/blob/4a08e2f/src/logging.ts#L69">logging.ts:69</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">

--- a/docs/classes/logger.html
+++ b/docs/classes/logger.html
@@ -116,7 +116,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/open-olive/loop-development-kit-node/blob/4a08e2f/src/logging.ts#L25">logging.ts:25</a></li>
+									<li>Defined in <a href="https://github.com/open-olive/loop-development-kit-node/blob/2576fcd/src/logging.ts#L25">logging.ts:25</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -167,7 +167,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/open-olive/loop-development-kit-node/blob/4a08e2f/src/logging.ts#L112">logging.ts:112</a></li>
+									<li>Defined in <a href="https://github.com/open-olive/loop-development-kit-node/blob/2576fcd/src/logging.ts#L112">logging.ts:112</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -215,7 +215,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/open-olive/loop-development-kit-node/blob/4a08e2f/src/logging.ts#L175">logging.ts:175</a></li>
+									<li>Defined in <a href="https://github.com/open-olive/loop-development-kit-node/blob/2576fcd/src/logging.ts#L175">logging.ts:175</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -263,7 +263,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/open-olive/loop-development-kit-node/blob/4a08e2f/src/logging.ts#L133">logging.ts:133</a></li>
+									<li>Defined in <a href="https://github.com/open-olive/loop-development-kit-node/blob/2576fcd/src/logging.ts#L133">logging.ts:133</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -311,7 +311,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/open-olive/loop-development-kit-node/blob/4a08e2f/src/logging.ts#L91">logging.ts:91</a></li>
+									<li>Defined in <a href="https://github.com/open-olive/loop-development-kit-node/blob/2576fcd/src/logging.ts#L91">logging.ts:91</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -359,7 +359,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/open-olive/loop-development-kit-node/blob/4a08e2f/src/logging.ts#L154">logging.ts:154</a></li>
+									<li>Defined in <a href="https://github.com/open-olive/loop-development-kit-node/blob/2576fcd/src/logging.ts#L154">logging.ts:154</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -407,7 +407,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/open-olive/loop-development-kit-node/blob/4a08e2f/src/logging.ts#L69">logging.ts:69</a></li>
+									<li>Defined in <a href="https://github.com/open-olive/loop-development-kit-node/blob/2576fcd/src/logging.ts#L69">logging.ts:69</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">

--- a/docs/classes/logger.html
+++ b/docs/classes/logger.html
@@ -116,7 +116,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/open-olive/loop-development-kit-node/blob/fa2b79d/src/logging.ts#L25">logging.ts:25</a></li>
+									<li>Defined in <a href="https://github.com/open-olive/loop-development-kit-node/blob/843e171/src/logging.ts#L25">logging.ts:25</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -167,7 +167,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/open-olive/loop-development-kit-node/blob/fa2b79d/src/logging.ts#L112">logging.ts:112</a></li>
+									<li>Defined in <a href="https://github.com/open-olive/loop-development-kit-node/blob/843e171/src/logging.ts#L112">logging.ts:112</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -215,7 +215,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/open-olive/loop-development-kit-node/blob/fa2b79d/src/logging.ts#L175">logging.ts:175</a></li>
+									<li>Defined in <a href="https://github.com/open-olive/loop-development-kit-node/blob/843e171/src/logging.ts#L175">logging.ts:175</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -263,7 +263,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/open-olive/loop-development-kit-node/blob/fa2b79d/src/logging.ts#L133">logging.ts:133</a></li>
+									<li>Defined in <a href="https://github.com/open-olive/loop-development-kit-node/blob/843e171/src/logging.ts#L133">logging.ts:133</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -311,7 +311,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/open-olive/loop-development-kit-node/blob/fa2b79d/src/logging.ts#L91">logging.ts:91</a></li>
+									<li>Defined in <a href="https://github.com/open-olive/loop-development-kit-node/blob/843e171/src/logging.ts#L91">logging.ts:91</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -359,7 +359,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/open-olive/loop-development-kit-node/blob/fa2b79d/src/logging.ts#L154">logging.ts:154</a></li>
+									<li>Defined in <a href="https://github.com/open-olive/loop-development-kit-node/blob/843e171/src/logging.ts#L154">logging.ts:154</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -407,7 +407,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/open-olive/loop-development-kit-node/blob/fa2b79d/src/logging.ts#L69">logging.ts:69</a></li>
+									<li>Defined in <a href="https://github.com/open-olive/loop-development-kit-node/blob/843e171/src/logging.ts#L69">logging.ts:69</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">

--- a/docs/classes/sensorplugin.html
+++ b/docs/classes/sensorplugin.html
@@ -111,7 +111,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/open-olive/loop-development-kit-node/blob/4a08e2f/src/sensorPlugin.ts#L17">sensorPlugin.ts:17</a></li>
+									<li>Defined in <a href="https://github.com/open-olive/loop-development-kit-node/blob/2576fcd/src/sensorPlugin.ts#L17">sensorPlugin.ts:17</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -148,7 +148,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/open-olive/loop-development-kit-node/blob/4a08e2f/src/sensorPlugin.ts#L41">sensorPlugin.ts:41</a></li>
+									<li>Defined in <a href="https://github.com/open-olive/loop-development-kit-node/blob/2576fcd/src/sensorPlugin.ts#L41">sensorPlugin.ts:41</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">

--- a/docs/classes/sensorplugin.html
+++ b/docs/classes/sensorplugin.html
@@ -111,7 +111,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/open-olive/loop-development-kit-node/blob/fa2b79d/src/sensorPlugin.ts#L17">sensorPlugin.ts:17</a></li>
+									<li>Defined in <a href="https://github.com/open-olive/loop-development-kit-node/blob/843e171/src/sensorPlugin.ts#L17">sensorPlugin.ts:17</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -148,7 +148,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/open-olive/loop-development-kit-node/blob/fa2b79d/src/sensorPlugin.ts#L41">sensorPlugin.ts:41</a></li>
+									<li>Defined in <a href="https://github.com/open-olive/loop-development-kit-node/blob/843e171/src/sensorPlugin.ts#L41">sensorPlugin.ts:41</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">

--- a/docs/classes/sensorplugin.html
+++ b/docs/classes/sensorplugin.html
@@ -111,7 +111,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/open-olive/loop-development-kit-node/blob/52d7210/src/sensorPlugin.ts#L17">sensorPlugin.ts:17</a></li>
+									<li>Defined in <a href="https://github.com/open-olive/loop-development-kit-node/blob/fa2b79d/src/sensorPlugin.ts#L17">sensorPlugin.ts:17</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -148,7 +148,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/open-olive/loop-development-kit-node/blob/52d7210/src/sensorPlugin.ts#L41">sensorPlugin.ts:41</a></li>
+									<li>Defined in <a href="https://github.com/open-olive/loop-development-kit-node/blob/fa2b79d/src/sensorPlugin.ts#L41">sensorPlugin.ts:41</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">

--- a/docs/classes/sensorplugin.html
+++ b/docs/classes/sensorplugin.html
@@ -111,7 +111,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/open-olive/loop-development-kit-node/blob/843e171/src/sensorPlugin.ts#L17">sensorPlugin.ts:17</a></li>
+									<li>Defined in <a href="https://github.com/open-olive/loop-development-kit-node/blob/4a08e2f/src/sensorPlugin.ts#L17">sensorPlugin.ts:17</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -148,7 +148,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/open-olive/loop-development-kit-node/blob/843e171/src/sensorPlugin.ts#L41">sensorPlugin.ts:41</a></li>
+									<li>Defined in <a href="https://github.com/open-olive/loop-development-kit-node/blob/4a08e2f/src/sensorPlugin.ts#L41">sensorPlugin.ts:41</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">

--- a/docs/enums/access.html
+++ b/docs/enums/access.html
@@ -89,7 +89,7 @@
 					<div class="tsd-signature tsd-kind-icon">ORGANIZATION<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-symbol"> = &quot;organization&quot;</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/open-olive/loop-development-kit-node/blob/4a08e2f/src/access.ts#L3">access.ts:3</a></li>
+							<li>Defined in <a href="https://github.com/open-olive/loop-development-kit-node/blob/2576fcd/src/access.ts#L3">access.ts:3</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -99,7 +99,7 @@
 					<div class="tsd-signature tsd-kind-icon">PUBLIC<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-symbol"> = &quot;public&quot;</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/open-olive/loop-development-kit-node/blob/4a08e2f/src/access.ts#L4">access.ts:4</a></li>
+							<li>Defined in <a href="https://github.com/open-olive/loop-development-kit-node/blob/2576fcd/src/access.ts#L4">access.ts:4</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -109,7 +109,7 @@
 					<div class="tsd-signature tsd-kind-icon">UNKNOWN<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-symbol"> = &quot;unknown&quot;</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/open-olive/loop-development-kit-node/blob/4a08e2f/src/access.ts#L5">access.ts:5</a></li>
+							<li>Defined in <a href="https://github.com/open-olive/loop-development-kit-node/blob/2576fcd/src/access.ts#L5">access.ts:5</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -119,7 +119,7 @@
 					<div class="tsd-signature tsd-kind-icon">USER<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-symbol"> = &quot;user&quot;</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/open-olive/loop-development-kit-node/blob/4a08e2f/src/access.ts#L6">access.ts:6</a></li>
+							<li>Defined in <a href="https://github.com/open-olive/loop-development-kit-node/blob/2576fcd/src/access.ts#L6">access.ts:6</a></li>
 						</ul>
 					</aside>
 				</section>

--- a/docs/enums/access.html
+++ b/docs/enums/access.html
@@ -89,7 +89,7 @@
 					<div class="tsd-signature tsd-kind-icon">ORGANIZATION<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-symbol"> = &quot;organization&quot;</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/open-olive/loop-development-kit-node/blob/fa2b79d/src/access.ts#L3">access.ts:3</a></li>
+							<li>Defined in <a href="https://github.com/open-olive/loop-development-kit-node/blob/843e171/src/access.ts#L3">access.ts:3</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -99,7 +99,7 @@
 					<div class="tsd-signature tsd-kind-icon">PUBLIC<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-symbol"> = &quot;public&quot;</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/open-olive/loop-development-kit-node/blob/fa2b79d/src/access.ts#L4">access.ts:4</a></li>
+							<li>Defined in <a href="https://github.com/open-olive/loop-development-kit-node/blob/843e171/src/access.ts#L4">access.ts:4</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -109,7 +109,7 @@
 					<div class="tsd-signature tsd-kind-icon">UNKNOWN<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-symbol"> = &quot;unknown&quot;</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/open-olive/loop-development-kit-node/blob/fa2b79d/src/access.ts#L5">access.ts:5</a></li>
+							<li>Defined in <a href="https://github.com/open-olive/loop-development-kit-node/blob/843e171/src/access.ts#L5">access.ts:5</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -119,7 +119,7 @@
 					<div class="tsd-signature tsd-kind-icon">USER<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-symbol"> = &quot;user&quot;</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/open-olive/loop-development-kit-node/blob/fa2b79d/src/access.ts#L6">access.ts:6</a></li>
+							<li>Defined in <a href="https://github.com/open-olive/loop-development-kit-node/blob/843e171/src/access.ts#L6">access.ts:6</a></li>
 						</ul>
 					</aside>
 				</section>

--- a/docs/enums/access.html
+++ b/docs/enums/access.html
@@ -89,7 +89,7 @@
 					<div class="tsd-signature tsd-kind-icon">ORGANIZATION<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-symbol"> = &quot;organization&quot;</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/open-olive/loop-development-kit-node/blob/843e171/src/access.ts#L3">access.ts:3</a></li>
+							<li>Defined in <a href="https://github.com/open-olive/loop-development-kit-node/blob/4a08e2f/src/access.ts#L3">access.ts:3</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -99,7 +99,7 @@
 					<div class="tsd-signature tsd-kind-icon">PUBLIC<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-symbol"> = &quot;public&quot;</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/open-olive/loop-development-kit-node/blob/843e171/src/access.ts#L4">access.ts:4</a></li>
+							<li>Defined in <a href="https://github.com/open-olive/loop-development-kit-node/blob/4a08e2f/src/access.ts#L4">access.ts:4</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -109,7 +109,7 @@
 					<div class="tsd-signature tsd-kind-icon">UNKNOWN<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-symbol"> = &quot;unknown&quot;</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/open-olive/loop-development-kit-node/blob/843e171/src/access.ts#L5">access.ts:5</a></li>
+							<li>Defined in <a href="https://github.com/open-olive/loop-development-kit-node/blob/4a08e2f/src/access.ts#L5">access.ts:5</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -119,7 +119,7 @@
 					<div class="tsd-signature tsd-kind-icon">USER<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-symbol"> = &quot;user&quot;</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/open-olive/loop-development-kit-node/blob/843e171/src/access.ts#L6">access.ts:6</a></li>
+							<li>Defined in <a href="https://github.com/open-olive/loop-development-kit-node/blob/4a08e2f/src/access.ts#L6">access.ts:6</a></li>
 						</ul>
 					</aside>
 				</section>

--- a/docs/enums/access.html
+++ b/docs/enums/access.html
@@ -89,7 +89,7 @@
 					<div class="tsd-signature tsd-kind-icon">ORGANIZATION<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-symbol"> = &quot;organization&quot;</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/open-olive/loop-development-kit-node/blob/52d7210/src/access.ts#L3">access.ts:3</a></li>
+							<li>Defined in <a href="https://github.com/open-olive/loop-development-kit-node/blob/fa2b79d/src/access.ts#L3">access.ts:3</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -99,7 +99,7 @@
 					<div class="tsd-signature tsd-kind-icon">PUBLIC<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-symbol"> = &quot;public&quot;</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/open-olive/loop-development-kit-node/blob/52d7210/src/access.ts#L4">access.ts:4</a></li>
+							<li>Defined in <a href="https://github.com/open-olive/loop-development-kit-node/blob/fa2b79d/src/access.ts#L4">access.ts:4</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -109,7 +109,7 @@
 					<div class="tsd-signature tsd-kind-icon">UNKNOWN<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-symbol"> = &quot;unknown&quot;</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/open-olive/loop-development-kit-node/blob/52d7210/src/access.ts#L5">access.ts:5</a></li>
+							<li>Defined in <a href="https://github.com/open-olive/loop-development-kit-node/blob/fa2b79d/src/access.ts#L5">access.ts:5</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -119,7 +119,7 @@
 					<div class="tsd-signature tsd-kind-icon">USER<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-symbol"> = &quot;user&quot;</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/open-olive/loop-development-kit-node/blob/52d7210/src/access.ts#L6">access.ts:6</a></li>
+							<li>Defined in <a href="https://github.com/open-olive/loop-development-kit-node/blob/fa2b79d/src/access.ts#L6">access.ts:6</a></li>
 						</ul>
 					</aside>
 				</section>

--- a/docs/enums/category.html
+++ b/docs/enums/category.html
@@ -90,7 +90,7 @@
 					<div class="tsd-signature tsd-kind-icon">CONTROLLER<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-symbol"> = &quot;Controller&quot;</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/open-olive/loop-development-kit-node/blob/4a08e2f/src/categories.ts#L3">categories.ts:3</a></li>
+							<li>Defined in <a href="https://github.com/open-olive/loop-development-kit-node/blob/2576fcd/src/categories.ts#L3">categories.ts:3</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -100,7 +100,7 @@
 					<div class="tsd-signature tsd-kind-icon">INTELLIGENCE<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-symbol"> = &quot;Intelligence&quot;</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/open-olive/loop-development-kit-node/blob/4a08e2f/src/categories.ts#L4">categories.ts:4</a></li>
+							<li>Defined in <a href="https://github.com/open-olive/loop-development-kit-node/blob/2576fcd/src/categories.ts#L4">categories.ts:4</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -110,7 +110,7 @@
 					<div class="tsd-signature tsd-kind-icon">SENSOR<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-symbol"> = &quot;Sensor&quot;</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/open-olive/loop-development-kit-node/blob/4a08e2f/src/categories.ts#L5">categories.ts:5</a></li>
+							<li>Defined in <a href="https://github.com/open-olive/loop-development-kit-node/blob/2576fcd/src/categories.ts#L5">categories.ts:5</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -120,7 +120,7 @@
 					<div class="tsd-signature tsd-kind-icon">SIDEKICK<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-symbol"> = &quot;Sidekick&quot;</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/open-olive/loop-development-kit-node/blob/4a08e2f/src/categories.ts#L6">categories.ts:6</a></li>
+							<li>Defined in <a href="https://github.com/open-olive/loop-development-kit-node/blob/2576fcd/src/categories.ts#L6">categories.ts:6</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -130,7 +130,7 @@
 					<div class="tsd-signature tsd-kind-icon">UNKNOWN<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-symbol"> = &quot;Unknown&quot;</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/open-olive/loop-development-kit-node/blob/4a08e2f/src/categories.ts#L7">categories.ts:7</a></li>
+							<li>Defined in <a href="https://github.com/open-olive/loop-development-kit-node/blob/2576fcd/src/categories.ts#L7">categories.ts:7</a></li>
 						</ul>
 					</aside>
 				</section>

--- a/docs/enums/category.html
+++ b/docs/enums/category.html
@@ -90,7 +90,7 @@
 					<div class="tsd-signature tsd-kind-icon">CONTROLLER<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-symbol"> = &quot;Controller&quot;</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/open-olive/loop-development-kit-node/blob/52d7210/src/categories.ts#L3">categories.ts:3</a></li>
+							<li>Defined in <a href="https://github.com/open-olive/loop-development-kit-node/blob/fa2b79d/src/categories.ts#L3">categories.ts:3</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -100,7 +100,7 @@
 					<div class="tsd-signature tsd-kind-icon">INTELLIGENCE<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-symbol"> = &quot;Intelligence&quot;</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/open-olive/loop-development-kit-node/blob/52d7210/src/categories.ts#L4">categories.ts:4</a></li>
+							<li>Defined in <a href="https://github.com/open-olive/loop-development-kit-node/blob/fa2b79d/src/categories.ts#L4">categories.ts:4</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -110,7 +110,7 @@
 					<div class="tsd-signature tsd-kind-icon">SENSOR<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-symbol"> = &quot;Sensor&quot;</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/open-olive/loop-development-kit-node/blob/52d7210/src/categories.ts#L5">categories.ts:5</a></li>
+							<li>Defined in <a href="https://github.com/open-olive/loop-development-kit-node/blob/fa2b79d/src/categories.ts#L5">categories.ts:5</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -120,7 +120,7 @@
 					<div class="tsd-signature tsd-kind-icon">SIDEKICK<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-symbol"> = &quot;Sidekick&quot;</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/open-olive/loop-development-kit-node/blob/52d7210/src/categories.ts#L6">categories.ts:6</a></li>
+							<li>Defined in <a href="https://github.com/open-olive/loop-development-kit-node/blob/fa2b79d/src/categories.ts#L6">categories.ts:6</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -130,7 +130,7 @@
 					<div class="tsd-signature tsd-kind-icon">UNKNOWN<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-symbol"> = &quot;Unknown&quot;</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/open-olive/loop-development-kit-node/blob/52d7210/src/categories.ts#L7">categories.ts:7</a></li>
+							<li>Defined in <a href="https://github.com/open-olive/loop-development-kit-node/blob/fa2b79d/src/categories.ts#L7">categories.ts:7</a></li>
 						</ul>
 					</aside>
 				</section>

--- a/docs/enums/category.html
+++ b/docs/enums/category.html
@@ -90,7 +90,7 @@
 					<div class="tsd-signature tsd-kind-icon">CONTROLLER<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-symbol"> = &quot;Controller&quot;</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/open-olive/loop-development-kit-node/blob/843e171/src/categories.ts#L3">categories.ts:3</a></li>
+							<li>Defined in <a href="https://github.com/open-olive/loop-development-kit-node/blob/4a08e2f/src/categories.ts#L3">categories.ts:3</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -100,7 +100,7 @@
 					<div class="tsd-signature tsd-kind-icon">INTELLIGENCE<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-symbol"> = &quot;Intelligence&quot;</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/open-olive/loop-development-kit-node/blob/843e171/src/categories.ts#L4">categories.ts:4</a></li>
+							<li>Defined in <a href="https://github.com/open-olive/loop-development-kit-node/blob/4a08e2f/src/categories.ts#L4">categories.ts:4</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -110,7 +110,7 @@
 					<div class="tsd-signature tsd-kind-icon">SENSOR<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-symbol"> = &quot;Sensor&quot;</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/open-olive/loop-development-kit-node/blob/843e171/src/categories.ts#L5">categories.ts:5</a></li>
+							<li>Defined in <a href="https://github.com/open-olive/loop-development-kit-node/blob/4a08e2f/src/categories.ts#L5">categories.ts:5</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -120,7 +120,7 @@
 					<div class="tsd-signature tsd-kind-icon">SIDEKICK<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-symbol"> = &quot;Sidekick&quot;</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/open-olive/loop-development-kit-node/blob/843e171/src/categories.ts#L6">categories.ts:6</a></li>
+							<li>Defined in <a href="https://github.com/open-olive/loop-development-kit-node/blob/4a08e2f/src/categories.ts#L6">categories.ts:6</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -130,7 +130,7 @@
 					<div class="tsd-signature tsd-kind-icon">UNKNOWN<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-symbol"> = &quot;Unknown&quot;</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/open-olive/loop-development-kit-node/blob/843e171/src/categories.ts#L7">categories.ts:7</a></li>
+							<li>Defined in <a href="https://github.com/open-olive/loop-development-kit-node/blob/4a08e2f/src/categories.ts#L7">categories.ts:7</a></li>
 						</ul>
 					</aside>
 				</section>

--- a/docs/enums/category.html
+++ b/docs/enums/category.html
@@ -90,7 +90,7 @@
 					<div class="tsd-signature tsd-kind-icon">CONTROLLER<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-symbol"> = &quot;Controller&quot;</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/open-olive/loop-development-kit-node/blob/fa2b79d/src/categories.ts#L3">categories.ts:3</a></li>
+							<li>Defined in <a href="https://github.com/open-olive/loop-development-kit-node/blob/843e171/src/categories.ts#L3">categories.ts:3</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -100,7 +100,7 @@
 					<div class="tsd-signature tsd-kind-icon">INTELLIGENCE<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-symbol"> = &quot;Intelligence&quot;</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/open-olive/loop-development-kit-node/blob/fa2b79d/src/categories.ts#L4">categories.ts:4</a></li>
+							<li>Defined in <a href="https://github.com/open-olive/loop-development-kit-node/blob/843e171/src/categories.ts#L4">categories.ts:4</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -110,7 +110,7 @@
 					<div class="tsd-signature tsd-kind-icon">SENSOR<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-symbol"> = &quot;Sensor&quot;</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/open-olive/loop-development-kit-node/blob/fa2b79d/src/categories.ts#L5">categories.ts:5</a></li>
+							<li>Defined in <a href="https://github.com/open-olive/loop-development-kit-node/blob/843e171/src/categories.ts#L5">categories.ts:5</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -120,7 +120,7 @@
 					<div class="tsd-signature tsd-kind-icon">SIDEKICK<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-symbol"> = &quot;Sidekick&quot;</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/open-olive/loop-development-kit-node/blob/fa2b79d/src/categories.ts#L6">categories.ts:6</a></li>
+							<li>Defined in <a href="https://github.com/open-olive/loop-development-kit-node/blob/843e171/src/categories.ts#L6">categories.ts:6</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -130,7 +130,7 @@
 					<div class="tsd-signature tsd-kind-icon">UNKNOWN<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-symbol"> = &quot;Unknown&quot;</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/open-olive/loop-development-kit-node/blob/fa2b79d/src/categories.ts#L7">categories.ts:7</a></li>
+							<li>Defined in <a href="https://github.com/open-olive/loop-development-kit-node/blob/843e171/src/categories.ts#L7">categories.ts:7</a></li>
 						</ul>
 					</aside>
 				</section>

--- a/docs/enums/operatingsystem.html
+++ b/docs/enums/operatingsystem.html
@@ -90,7 +90,7 @@
 					<div class="tsd-signature tsd-kind-icon">ANY<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-symbol"> = &quot;any&quot;</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/open-olive/loop-development-kit-node/blob/fa2b79d/src/operatingSystem.ts#L3">operatingSystem.ts:3</a></li>
+							<li>Defined in <a href="https://github.com/open-olive/loop-development-kit-node/blob/843e171/src/operatingSystem.ts#L3">operatingSystem.ts:3</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -100,7 +100,7 @@
 					<div class="tsd-signature tsd-kind-icon">LINUX<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-symbol"> = &quot;linux&quot;</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/open-olive/loop-development-kit-node/blob/fa2b79d/src/operatingSystem.ts#L4">operatingSystem.ts:4</a></li>
+							<li>Defined in <a href="https://github.com/open-olive/loop-development-kit-node/blob/843e171/src/operatingSystem.ts#L4">operatingSystem.ts:4</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -110,7 +110,7 @@
 					<div class="tsd-signature tsd-kind-icon">MACOS<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-symbol"> = &quot;darwin&quot;</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/open-olive/loop-development-kit-node/blob/fa2b79d/src/operatingSystem.ts#L5">operatingSystem.ts:5</a></li>
+							<li>Defined in <a href="https://github.com/open-olive/loop-development-kit-node/blob/843e171/src/operatingSystem.ts#L5">operatingSystem.ts:5</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -120,7 +120,7 @@
 					<div class="tsd-signature tsd-kind-icon">UNKNOWN<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-symbol"> = &quot;unknown&quot;</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/open-olive/loop-development-kit-node/blob/fa2b79d/src/operatingSystem.ts#L6">operatingSystem.ts:6</a></li>
+							<li>Defined in <a href="https://github.com/open-olive/loop-development-kit-node/blob/843e171/src/operatingSystem.ts#L6">operatingSystem.ts:6</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -130,7 +130,7 @@
 					<div class="tsd-signature tsd-kind-icon">WINDOWS<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-symbol"> = &quot;win32&quot;</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/open-olive/loop-development-kit-node/blob/fa2b79d/src/operatingSystem.ts#L7">operatingSystem.ts:7</a></li>
+							<li>Defined in <a href="https://github.com/open-olive/loop-development-kit-node/blob/843e171/src/operatingSystem.ts#L7">operatingSystem.ts:7</a></li>
 						</ul>
 					</aside>
 				</section>

--- a/docs/enums/operatingsystem.html
+++ b/docs/enums/operatingsystem.html
@@ -90,7 +90,7 @@
 					<div class="tsd-signature tsd-kind-icon">ANY<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-symbol"> = &quot;any&quot;</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/open-olive/loop-development-kit-node/blob/52d7210/src/operatingSystem.ts#L3">operatingSystem.ts:3</a></li>
+							<li>Defined in <a href="https://github.com/open-olive/loop-development-kit-node/blob/fa2b79d/src/operatingSystem.ts#L3">operatingSystem.ts:3</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -100,7 +100,7 @@
 					<div class="tsd-signature tsd-kind-icon">LINUX<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-symbol"> = &quot;linux&quot;</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/open-olive/loop-development-kit-node/blob/52d7210/src/operatingSystem.ts#L4">operatingSystem.ts:4</a></li>
+							<li>Defined in <a href="https://github.com/open-olive/loop-development-kit-node/blob/fa2b79d/src/operatingSystem.ts#L4">operatingSystem.ts:4</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -110,7 +110,7 @@
 					<div class="tsd-signature tsd-kind-icon">MACOS<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-symbol"> = &quot;darwin&quot;</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/open-olive/loop-development-kit-node/blob/52d7210/src/operatingSystem.ts#L5">operatingSystem.ts:5</a></li>
+							<li>Defined in <a href="https://github.com/open-olive/loop-development-kit-node/blob/fa2b79d/src/operatingSystem.ts#L5">operatingSystem.ts:5</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -120,7 +120,7 @@
 					<div class="tsd-signature tsd-kind-icon">UNKNOWN<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-symbol"> = &quot;unknown&quot;</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/open-olive/loop-development-kit-node/blob/52d7210/src/operatingSystem.ts#L6">operatingSystem.ts:6</a></li>
+							<li>Defined in <a href="https://github.com/open-olive/loop-development-kit-node/blob/fa2b79d/src/operatingSystem.ts#L6">operatingSystem.ts:6</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -130,7 +130,7 @@
 					<div class="tsd-signature tsd-kind-icon">WINDOWS<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-symbol"> = &quot;win32&quot;</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/open-olive/loop-development-kit-node/blob/52d7210/src/operatingSystem.ts#L7">operatingSystem.ts:7</a></li>
+							<li>Defined in <a href="https://github.com/open-olive/loop-development-kit-node/blob/fa2b79d/src/operatingSystem.ts#L7">operatingSystem.ts:7</a></li>
 						</ul>
 					</aside>
 				</section>

--- a/docs/enums/operatingsystem.html
+++ b/docs/enums/operatingsystem.html
@@ -90,7 +90,7 @@
 					<div class="tsd-signature tsd-kind-icon">ANY<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-symbol"> = &quot;any&quot;</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/open-olive/loop-development-kit-node/blob/4a08e2f/src/operatingSystem.ts#L3">operatingSystem.ts:3</a></li>
+							<li>Defined in <a href="https://github.com/open-olive/loop-development-kit-node/blob/2576fcd/src/operatingSystem.ts#L3">operatingSystem.ts:3</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -100,7 +100,7 @@
 					<div class="tsd-signature tsd-kind-icon">LINUX<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-symbol"> = &quot;linux&quot;</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/open-olive/loop-development-kit-node/blob/4a08e2f/src/operatingSystem.ts#L4">operatingSystem.ts:4</a></li>
+							<li>Defined in <a href="https://github.com/open-olive/loop-development-kit-node/blob/2576fcd/src/operatingSystem.ts#L4">operatingSystem.ts:4</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -110,7 +110,7 @@
 					<div class="tsd-signature tsd-kind-icon">MACOS<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-symbol"> = &quot;darwin&quot;</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/open-olive/loop-development-kit-node/blob/4a08e2f/src/operatingSystem.ts#L5">operatingSystem.ts:5</a></li>
+							<li>Defined in <a href="https://github.com/open-olive/loop-development-kit-node/blob/2576fcd/src/operatingSystem.ts#L5">operatingSystem.ts:5</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -120,7 +120,7 @@
 					<div class="tsd-signature tsd-kind-icon">UNKNOWN<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-symbol"> = &quot;unknown&quot;</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/open-olive/loop-development-kit-node/blob/4a08e2f/src/operatingSystem.ts#L6">operatingSystem.ts:6</a></li>
+							<li>Defined in <a href="https://github.com/open-olive/loop-development-kit-node/blob/2576fcd/src/operatingSystem.ts#L6">operatingSystem.ts:6</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -130,7 +130,7 @@
 					<div class="tsd-signature tsd-kind-icon">WINDOWS<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-symbol"> = &quot;win32&quot;</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/open-olive/loop-development-kit-node/blob/4a08e2f/src/operatingSystem.ts#L7">operatingSystem.ts:7</a></li>
+							<li>Defined in <a href="https://github.com/open-olive/loop-development-kit-node/blob/2576fcd/src/operatingSystem.ts#L7">operatingSystem.ts:7</a></li>
 						</ul>
 					</aside>
 				</section>

--- a/docs/enums/operatingsystem.html
+++ b/docs/enums/operatingsystem.html
@@ -90,7 +90,7 @@
 					<div class="tsd-signature tsd-kind-icon">ANY<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-symbol"> = &quot;any&quot;</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/open-olive/loop-development-kit-node/blob/843e171/src/operatingSystem.ts#L3">operatingSystem.ts:3</a></li>
+							<li>Defined in <a href="https://github.com/open-olive/loop-development-kit-node/blob/4a08e2f/src/operatingSystem.ts#L3">operatingSystem.ts:3</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -100,7 +100,7 @@
 					<div class="tsd-signature tsd-kind-icon">LINUX<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-symbol"> = &quot;linux&quot;</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/open-olive/loop-development-kit-node/blob/843e171/src/operatingSystem.ts#L4">operatingSystem.ts:4</a></li>
+							<li>Defined in <a href="https://github.com/open-olive/loop-development-kit-node/blob/4a08e2f/src/operatingSystem.ts#L4">operatingSystem.ts:4</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -110,7 +110,7 @@
 					<div class="tsd-signature tsd-kind-icon">MACOS<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-symbol"> = &quot;darwin&quot;</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/open-olive/loop-development-kit-node/blob/843e171/src/operatingSystem.ts#L5">operatingSystem.ts:5</a></li>
+							<li>Defined in <a href="https://github.com/open-olive/loop-development-kit-node/blob/4a08e2f/src/operatingSystem.ts#L5">operatingSystem.ts:5</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -120,7 +120,7 @@
 					<div class="tsd-signature tsd-kind-icon">UNKNOWN<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-symbol"> = &quot;unknown&quot;</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/open-olive/loop-development-kit-node/blob/843e171/src/operatingSystem.ts#L6">operatingSystem.ts:6</a></li>
+							<li>Defined in <a href="https://github.com/open-olive/loop-development-kit-node/blob/4a08e2f/src/operatingSystem.ts#L6">operatingSystem.ts:6</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -130,7 +130,7 @@
 					<div class="tsd-signature tsd-kind-icon">WINDOWS<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-symbol"> = &quot;win32&quot;</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/open-olive/loop-development-kit-node/blob/843e171/src/operatingSystem.ts#L7">operatingSystem.ts:7</a></li>
+							<li>Defined in <a href="https://github.com/open-olive/loop-development-kit-node/blob/4a08e2f/src/operatingSystem.ts#L7">operatingSystem.ts:7</a></li>
 						</ul>
 					</aside>
 				</section>

--- a/docs/globals.html
+++ b/docs/globals.html
@@ -129,7 +129,7 @@
 					<div class="tsd-signature tsd-kind-icon">Request&lt;TRequestType, TResponseType&gt;<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-symbol">(</span>request<span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">TRequestType</span>, callback<span class="tsd-signature-symbol">: </span><span class="tsd-signature-symbol">(</span>error<span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">grpc.ServiceError</span><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">null</span>, response<span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">TResponseType</span><span class="tsd-signature-symbol">)</span><span class="tsd-signature-symbol"> =&gt; </span><span class="tsd-signature-type">void</span><span class="tsd-signature-symbol">)</span><span class="tsd-signature-symbol"> =&gt; </span><span class="tsd-signature-type">void</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/open-olive/loop-development-kit-node/blob/52d7210/src/commonHostServer.ts#L5">commonHostServer.ts:5</a></li>
+							<li>Defined in <a href="https://github.com/open-olive/loop-development-kit-node/blob/fa2b79d/src/commonHostServer.ts#L5">commonHostServer.ts:5</a></li>
 						</ul>
 					</aside>
 					<h4 class="tsd-type-parameters-title">Type parameters</h4>
@@ -196,7 +196,7 @@
 					<div class="tsd-signature tsd-kind-icon">categories<span class="tsd-signature-symbol">:</span> <a href="enums/category.html" class="tsd-signature-type">Category</a><span class="tsd-signature-symbol">[]</span><span class="tsd-signature-symbol"> = [Category.UNKNOWN,Category.INTELLIGENCE,Category.CONTROLLER,Category.SENSOR,Category.SIDEKICK,]</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/open-olive/loop-development-kit-node/blob/52d7210/src/categories.ts#L10">categories.ts:10</a></li>
+							<li>Defined in <a href="https://github.com/open-olive/loop-development-kit-node/blob/fa2b79d/src/categories.ts#L10">categories.ts:10</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -206,7 +206,7 @@
 					<div class="tsd-signature tsd-kind-icon">err<wbr>Missing<wbr>Required<wbr>Key<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">Error</span><span class="tsd-signature-symbol"> = new Error(&#x27;key is required&#x27;)</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/open-olive/loop-development-kit-node/blob/52d7210/src/grpcHostClient.ts#L6">grpcHostClient.ts:6</a></li>
+							<li>Defined in <a href="https://github.com/open-olive/loop-development-kit-node/blob/fa2b79d/src/grpcHostClient.ts#L6">grpcHostClient.ts:6</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -216,7 +216,7 @@
 					<div class="tsd-signature tsd-kind-icon">err<wbr>Missing<wbr>Required<wbr>Value<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">Error</span><span class="tsd-signature-symbol"> = new Error(&#x27;value is required&#x27;)</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/open-olive/loop-development-kit-node/blob/52d7210/src/grpcHostClient.ts#L7">grpcHostClient.ts:7</a></li>
+							<li>Defined in <a href="https://github.com/open-olive/loop-development-kit-node/blob/fa2b79d/src/grpcHostClient.ts#L7">grpcHostClient.ts:7</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -226,7 +226,7 @@
 					<div class="tsd-signature tsd-kind-icon">pid<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">number</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/open-olive/loop-development-kit-node/blob/52d7210/src/logging.ts#L6">logging.ts:6</a></li>
+							<li>Defined in <a href="https://github.com/open-olive/loop-development-kit-node/blob/fa2b79d/src/logging.ts#L6">logging.ts:6</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -236,7 +236,7 @@
 					<div class="tsd-signature tsd-kind-icon">program<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">Command</span><span class="tsd-signature-symbol"> = new Command()</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/open-olive/loop-development-kit-node/blob/52d7210/src/commands.ts#L4">commands.ts:4</a></li>
+							<li>Defined in <a href="https://github.com/open-olive/loop-development-kit-node/blob/fa2b79d/src/commands.ts#L4">commands.ts:4</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -253,7 +253,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/open-olive/loop-development-kit-node/blob/52d7210/src/serve.ts#L11">serve.ts:11</a></li>
+									<li>Defined in <a href="https://github.com/open-olive/loop-development-kit-node/blob/fa2b79d/src/serve.ts#L11">serve.ts:11</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -284,7 +284,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/open-olive/loop-development-kit-node/blob/52d7210/src/serve.ts#L21">serve.ts:21</a></li>
+									<li>Defined in <a href="https://github.com/open-olive/loop-development-kit-node/blob/fa2b79d/src/serve.ts#L21">serve.ts:21</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">

--- a/docs/globals.html
+++ b/docs/globals.html
@@ -129,7 +129,7 @@
 					<div class="tsd-signature tsd-kind-icon">Request&lt;TRequestType, TResponseType&gt;<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-symbol">(</span>request<span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">TRequestType</span>, callback<span class="tsd-signature-symbol">: </span><span class="tsd-signature-symbol">(</span>error<span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">grpc.ServiceError</span><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">null</span>, response<span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">TResponseType</span><span class="tsd-signature-symbol">)</span><span class="tsd-signature-symbol"> =&gt; </span><span class="tsd-signature-type">void</span><span class="tsd-signature-symbol">)</span><span class="tsd-signature-symbol"> =&gt; </span><span class="tsd-signature-type">void</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/open-olive/loop-development-kit-node/blob/4a08e2f/src/commonHostServer.ts#L5">commonHostServer.ts:5</a></li>
+							<li>Defined in <a href="https://github.com/open-olive/loop-development-kit-node/blob/2576fcd/src/commonHostServer.ts#L5">commonHostServer.ts:5</a></li>
 						</ul>
 					</aside>
 					<h4 class="tsd-type-parameters-title">Type parameters</h4>
@@ -196,7 +196,7 @@
 					<div class="tsd-signature tsd-kind-icon">categories<span class="tsd-signature-symbol">:</span> <a href="enums/category.html" class="tsd-signature-type">Category</a><span class="tsd-signature-symbol">[]</span><span class="tsd-signature-symbol"> = [Category.UNKNOWN,Category.INTELLIGENCE,Category.CONTROLLER,Category.SENSOR,Category.SIDEKICK,]</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/open-olive/loop-development-kit-node/blob/4a08e2f/src/categories.ts#L10">categories.ts:10</a></li>
+							<li>Defined in <a href="https://github.com/open-olive/loop-development-kit-node/blob/2576fcd/src/categories.ts#L10">categories.ts:10</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -206,7 +206,7 @@
 					<div class="tsd-signature tsd-kind-icon">err<wbr>Missing<wbr>Required<wbr>Key<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">Error</span><span class="tsd-signature-symbol"> = new Error(&#x27;key is required&#x27;)</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/open-olive/loop-development-kit-node/blob/4a08e2f/src/grpcHostClient.ts#L6">grpcHostClient.ts:6</a></li>
+							<li>Defined in <a href="https://github.com/open-olive/loop-development-kit-node/blob/2576fcd/src/grpcHostClient.ts#L6">grpcHostClient.ts:6</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -216,7 +216,7 @@
 					<div class="tsd-signature tsd-kind-icon">err<wbr>Missing<wbr>Required<wbr>Value<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">Error</span><span class="tsd-signature-symbol"> = new Error(&#x27;value is required&#x27;)</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/open-olive/loop-development-kit-node/blob/4a08e2f/src/grpcHostClient.ts#L7">grpcHostClient.ts:7</a></li>
+							<li>Defined in <a href="https://github.com/open-olive/loop-development-kit-node/blob/2576fcd/src/grpcHostClient.ts#L7">grpcHostClient.ts:7</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -226,7 +226,7 @@
 					<div class="tsd-signature tsd-kind-icon">pid<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">number</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/open-olive/loop-development-kit-node/blob/4a08e2f/src/logging.ts#L6">logging.ts:6</a></li>
+							<li>Defined in <a href="https://github.com/open-olive/loop-development-kit-node/blob/2576fcd/src/logging.ts#L6">logging.ts:6</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -236,7 +236,7 @@
 					<div class="tsd-signature tsd-kind-icon">program<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">Command</span><span class="tsd-signature-symbol"> = new Command()</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/open-olive/loop-development-kit-node/blob/4a08e2f/src/commands.ts#L4">commands.ts:4</a></li>
+							<li>Defined in <a href="https://github.com/open-olive/loop-development-kit-node/blob/2576fcd/src/commands.ts#L4">commands.ts:4</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -253,7 +253,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/open-olive/loop-development-kit-node/blob/4a08e2f/src/serve.ts#L11">serve.ts:11</a></li>
+									<li>Defined in <a href="https://github.com/open-olive/loop-development-kit-node/blob/2576fcd/src/serve.ts#L11">serve.ts:11</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -284,7 +284,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/open-olive/loop-development-kit-node/blob/4a08e2f/src/serve.ts#L21">serve.ts:21</a></li>
+									<li>Defined in <a href="https://github.com/open-olive/loop-development-kit-node/blob/2576fcd/src/serve.ts#L21">serve.ts:21</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">

--- a/docs/globals.html
+++ b/docs/globals.html
@@ -129,7 +129,7 @@
 					<div class="tsd-signature tsd-kind-icon">Request&lt;TRequestType, TResponseType&gt;<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-symbol">(</span>request<span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">TRequestType</span>, callback<span class="tsd-signature-symbol">: </span><span class="tsd-signature-symbol">(</span>error<span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">grpc.ServiceError</span><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">null</span>, response<span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">TResponseType</span><span class="tsd-signature-symbol">)</span><span class="tsd-signature-symbol"> =&gt; </span><span class="tsd-signature-type">void</span><span class="tsd-signature-symbol">)</span><span class="tsd-signature-symbol"> =&gt; </span><span class="tsd-signature-type">void</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/open-olive/loop-development-kit-node/blob/843e171/src/commonHostServer.ts#L5">commonHostServer.ts:5</a></li>
+							<li>Defined in <a href="https://github.com/open-olive/loop-development-kit-node/blob/4a08e2f/src/commonHostServer.ts#L5">commonHostServer.ts:5</a></li>
 						</ul>
 					</aside>
 					<h4 class="tsd-type-parameters-title">Type parameters</h4>
@@ -196,7 +196,7 @@
 					<div class="tsd-signature tsd-kind-icon">categories<span class="tsd-signature-symbol">:</span> <a href="enums/category.html" class="tsd-signature-type">Category</a><span class="tsd-signature-symbol">[]</span><span class="tsd-signature-symbol"> = [Category.UNKNOWN,Category.INTELLIGENCE,Category.CONTROLLER,Category.SENSOR,Category.SIDEKICK,]</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/open-olive/loop-development-kit-node/blob/843e171/src/categories.ts#L10">categories.ts:10</a></li>
+							<li>Defined in <a href="https://github.com/open-olive/loop-development-kit-node/blob/4a08e2f/src/categories.ts#L10">categories.ts:10</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -206,7 +206,7 @@
 					<div class="tsd-signature tsd-kind-icon">err<wbr>Missing<wbr>Required<wbr>Key<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">Error</span><span class="tsd-signature-symbol"> = new Error(&#x27;key is required&#x27;)</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/open-olive/loop-development-kit-node/blob/843e171/src/grpcHostClient.ts#L6">grpcHostClient.ts:6</a></li>
+							<li>Defined in <a href="https://github.com/open-olive/loop-development-kit-node/blob/4a08e2f/src/grpcHostClient.ts#L6">grpcHostClient.ts:6</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -216,7 +216,7 @@
 					<div class="tsd-signature tsd-kind-icon">err<wbr>Missing<wbr>Required<wbr>Value<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">Error</span><span class="tsd-signature-symbol"> = new Error(&#x27;value is required&#x27;)</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/open-olive/loop-development-kit-node/blob/843e171/src/grpcHostClient.ts#L7">grpcHostClient.ts:7</a></li>
+							<li>Defined in <a href="https://github.com/open-olive/loop-development-kit-node/blob/4a08e2f/src/grpcHostClient.ts#L7">grpcHostClient.ts:7</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -226,7 +226,7 @@
 					<div class="tsd-signature tsd-kind-icon">pid<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">number</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/open-olive/loop-development-kit-node/blob/843e171/src/logging.ts#L6">logging.ts:6</a></li>
+							<li>Defined in <a href="https://github.com/open-olive/loop-development-kit-node/blob/4a08e2f/src/logging.ts#L6">logging.ts:6</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -236,7 +236,7 @@
 					<div class="tsd-signature tsd-kind-icon">program<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">Command</span><span class="tsd-signature-symbol"> = new Command()</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/open-olive/loop-development-kit-node/blob/843e171/src/commands.ts#L4">commands.ts:4</a></li>
+							<li>Defined in <a href="https://github.com/open-olive/loop-development-kit-node/blob/4a08e2f/src/commands.ts#L4">commands.ts:4</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -253,7 +253,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/open-olive/loop-development-kit-node/blob/843e171/src/serve.ts#L11">serve.ts:11</a></li>
+									<li>Defined in <a href="https://github.com/open-olive/loop-development-kit-node/blob/4a08e2f/src/serve.ts#L11">serve.ts:11</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -284,7 +284,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/open-olive/loop-development-kit-node/blob/843e171/src/serve.ts#L21">serve.ts:21</a></li>
+									<li>Defined in <a href="https://github.com/open-olive/loop-development-kit-node/blob/4a08e2f/src/serve.ts#L21">serve.ts:21</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">

--- a/docs/globals.html
+++ b/docs/globals.html
@@ -129,7 +129,7 @@
 					<div class="tsd-signature tsd-kind-icon">Request&lt;TRequestType, TResponseType&gt;<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-symbol">(</span>request<span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">TRequestType</span>, callback<span class="tsd-signature-symbol">: </span><span class="tsd-signature-symbol">(</span>error<span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">grpc.ServiceError</span><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">null</span>, response<span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">TResponseType</span><span class="tsd-signature-symbol">)</span><span class="tsd-signature-symbol"> =&gt; </span><span class="tsd-signature-type">void</span><span class="tsd-signature-symbol">)</span><span class="tsd-signature-symbol"> =&gt; </span><span class="tsd-signature-type">void</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/open-olive/loop-development-kit-node/blob/fa2b79d/src/commonHostServer.ts#L5">commonHostServer.ts:5</a></li>
+							<li>Defined in <a href="https://github.com/open-olive/loop-development-kit-node/blob/843e171/src/commonHostServer.ts#L5">commonHostServer.ts:5</a></li>
 						</ul>
 					</aside>
 					<h4 class="tsd-type-parameters-title">Type parameters</h4>
@@ -196,7 +196,7 @@
 					<div class="tsd-signature tsd-kind-icon">categories<span class="tsd-signature-symbol">:</span> <a href="enums/category.html" class="tsd-signature-type">Category</a><span class="tsd-signature-symbol">[]</span><span class="tsd-signature-symbol"> = [Category.UNKNOWN,Category.INTELLIGENCE,Category.CONTROLLER,Category.SENSOR,Category.SIDEKICK,]</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/open-olive/loop-development-kit-node/blob/fa2b79d/src/categories.ts#L10">categories.ts:10</a></li>
+							<li>Defined in <a href="https://github.com/open-olive/loop-development-kit-node/blob/843e171/src/categories.ts#L10">categories.ts:10</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -206,7 +206,7 @@
 					<div class="tsd-signature tsd-kind-icon">err<wbr>Missing<wbr>Required<wbr>Key<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">Error</span><span class="tsd-signature-symbol"> = new Error(&#x27;key is required&#x27;)</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/open-olive/loop-development-kit-node/blob/fa2b79d/src/grpcHostClient.ts#L6">grpcHostClient.ts:6</a></li>
+							<li>Defined in <a href="https://github.com/open-olive/loop-development-kit-node/blob/843e171/src/grpcHostClient.ts#L6">grpcHostClient.ts:6</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -216,7 +216,7 @@
 					<div class="tsd-signature tsd-kind-icon">err<wbr>Missing<wbr>Required<wbr>Value<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">Error</span><span class="tsd-signature-symbol"> = new Error(&#x27;value is required&#x27;)</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/open-olive/loop-development-kit-node/blob/fa2b79d/src/grpcHostClient.ts#L7">grpcHostClient.ts:7</a></li>
+							<li>Defined in <a href="https://github.com/open-olive/loop-development-kit-node/blob/843e171/src/grpcHostClient.ts#L7">grpcHostClient.ts:7</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -226,7 +226,7 @@
 					<div class="tsd-signature tsd-kind-icon">pid<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">number</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/open-olive/loop-development-kit-node/blob/fa2b79d/src/logging.ts#L6">logging.ts:6</a></li>
+							<li>Defined in <a href="https://github.com/open-olive/loop-development-kit-node/blob/843e171/src/logging.ts#L6">logging.ts:6</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -236,7 +236,7 @@
 					<div class="tsd-signature tsd-kind-icon">program<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">Command</span><span class="tsd-signature-symbol"> = new Command()</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/open-olive/loop-development-kit-node/blob/fa2b79d/src/commands.ts#L4">commands.ts:4</a></li>
+							<li>Defined in <a href="https://github.com/open-olive/loop-development-kit-node/blob/843e171/src/commands.ts#L4">commands.ts:4</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -253,7 +253,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/open-olive/loop-development-kit-node/blob/fa2b79d/src/serve.ts#L11">serve.ts:11</a></li>
+									<li>Defined in <a href="https://github.com/open-olive/loop-development-kit-node/blob/843e171/src/serve.ts#L11">serve.ts:11</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -284,7 +284,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/open-olive/loop-development-kit-node/blob/fa2b79d/src/serve.ts#L21">serve.ts:21</a></li>
+									<li>Defined in <a href="https://github.com/open-olive/loop-development-kit-node/blob/843e171/src/serve.ts#L21">serve.ts:21</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">

--- a/docs/index.html
+++ b/docs/index.html
@@ -80,7 +80,7 @@
 					<li>Create your <code>package.json</code> file.</li>
 					<li>Import the LDK.</li>
 					<li>Create your <code>main</code> script (usually <code>index.js</code> or <code>src/index.js</code>):<ul>
-							<li>Create an implementation object that satisfies the <code>Controller</code> or <code>Sensor</code> contracts/interfaces.</li>
+							<li>Create an implementation object that satisfies the <a href="interfaces/controller.html">Controller</a> or <a href="interfaces/sensor.html">Sensor</a> contracts/interfaces.</li>
 							<li>Initialize the appropriate plugin with your implementation and call <code>.serve</code> on it.</li>
 						</ul>
 					</li>

--- a/docs/index.html
+++ b/docs/index.html
@@ -77,26 +77,19 @@
 				</a>
 				<p>Sidekick expects your library to start its Controller or Sensor GRPC server when launched. The LDK takes care of most of that for you, what you need to do is:</p>
 				<ul>
-					<li><p>Create your <code>package.json</code> file.</p>
-					</li>
-					<li><p>Import the LDK.</p>
-					</li>
-					<li><p>Create your <code>main</code> script (usually <code>index.js</code> or <code>src/index.js</code>):</p>
-						<ul>
-							<li>Create an implementation object that satisfies the <a href="interfaces/controller.html">Controller</a> or <a href="interfaces/sensor.html">Sensor</a> contracts/interfaces.</li>
+					<li>Create your <code>package.json</code> file.</li>
+					<li>Import the LDK.</li>
+					<li>Create your <code>main</code> script (usually <code>index.js</code> or <code>src/index.js</code>):<ul>
+							<li>Create an implementation object that satisfies the <code>Controller</code> or <code>Sensor</code> contracts/interfaces.</li>
 							<li>Initialize the appropriate plugin with your implementation and call <code>.serve</code> on it.</li>
 						</ul>
 					</li>
 				</ul>
 				<a href="#install-the-package" id="install-the-package" style="color: inherit; text-decoration: none;">
-					<h4>Install the package</h4>
+					<h4>Install the Package</h4>
 				</a>
-				<p>Add the dependency to your package.json under the dependencies:</p>
-				<pre><code class="language-json">&quot;dependencies&quot;: {
-  &quot;ldk&quot;: &quot;git+https://github.com/open-olive/loop-development-kit-node.git&quot;
-}</code></pre>
-				<p>Install using NPM</p>
-				<pre><code class="language-shell">npm i</code></pre>
+				<p>Install this library as a dependency:</p>
+				<pre><code class="language-shell">npm i @oliveai/ldk -P</code></pre>
 				<a href="#example-controller" id="example-controller" style="color: inherit; text-decoration: none;">
 					<h5>Example Controller</h5>
 				</a>
@@ -126,13 +119,11 @@ serveSensorPlugin(impl);</code></pre>
 				<p>Sidekick lets you add a local command as Local Plugins:</p>
 				<ol>
 					<li>Open Sidekick.</li>
-					<li>Open the Loop Library:</li>
-				</ol>
-				<ul>
-					<li>Click the Hamburger icon.</li>
-					<li>Click Loop Library.</li>
-				</ul>
-				<ol start="3">
+					<li>Open the Loop Library:<ol>
+							<li>Click the Hamburger icon.</li>
+							<li>Click Loop Library.</li>
+						</ol>
+					</li>
 					<li>Click the Install Local Plugin button:</li>
 					<li>Select whether it&#39;s a Controller or Sensor.</li>
 					<li>Select the working directory for the command.</li>
@@ -149,9 +140,9 @@ serveSensorPlugin(impl);</code></pre>
 				</a>
 				<p>Sidekick logs are available in the following directories for your OS:</p>
 				<pre><code class="language-shell">~/Library/Logs/Sidekick # MacOS
-/var/log/Sidekick # Linux
-<span class="hljs-meta">%</span><span class="bash">AppData%/Logs <span class="hljs-comment"># Windows</span></span></code></pre>
-				<p><code>tail</code> the log file (usually <code>Sidekick-X.Y.Z.log</code>) to watch things happen!</p>
+/var/log/Sidekick       # Linux
+<span class="hljs-meta">%</span><span class="bash">AppData%/Logs          <span class="hljs-comment"># Windows</span></span></code></pre>
+				<p><code>tail -f</code> the log file (usually <code>Sidekick-X.Y.Z.log</code>) to watch things happen!</p>
 				<a href="#deploying" id="deploying" style="color: inherit; text-decoration: none;">
 					<h2>Deploying</h2>
 				</a>
@@ -163,8 +154,9 @@ serveSensorPlugin(impl);</code></pre>
 					<h3>Commands</h3>
 				</a>
 				<p>We&#39;ve made the following commands available to you:</p>
-				<pre><code>ldk build <span class="hljs-comment"># Builds your project. Expects that you have index.js as your entry point, plugin.json, storage.json files.</span>
-ldk <span class="hljs-keyword">deploy</span> <span class="hljs-comment"># Deploys your project to the Application Support/Sidekick/plugins/controllers/YOUR_PACKAGE_NAME folder</span></code></pre><p>Each command takes options. Run <code>ldk help &lt;command&gt;</code> for details.</p>
+				<pre><code class="language-shell">ldk build # Builds your project. Expects that you have index.js as your entry point, plugin.json, storage.json files.
+ldk deploy # Deploys your project to the Application Support/Sidekick/plugins/controllers/YOUR_PACKAGE_NAME folder</code></pre>
+				<p>Each command takes options. Run <code>ldk help &lt;command&gt;</code> for details.</p>
 				<a href="#configuration" id="configuration" style="color: inherit; text-decoration: none;">
 					<h3>Configuration</h3>
 				</a>
@@ -187,7 +179,7 @@ ldk <span class="hljs-keyword">deploy</span> <span class="hljs-comment"># Deploy
 				<a href="#storagejson" id="storagejson" style="color: inherit; text-decoration: none;">
 					<h4><code>storage.json</code></h4>
 				</a>
-				<p>Each storage key you access must be specified in the <code>storage.json</code> file. </p>
+				<p>Each storage key you access must be specified in the <code>storage.json</code> file.</p>
 				<pre><code class="language-json">{
   <span class="hljs-attr">&quot;storage-key&quot;</span>: {
     <span class="hljs-attr">&quot;name&quot;</span>: <span class="hljs-string">&quot;Storage Key Name&quot;</span>,

--- a/docs/interfaces/controller.html
+++ b/docs/interfaces/controller.html
@@ -141,7 +141,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/open-olive/loop-development-kit-node/blob/843e171/src/controller.ts#L63">controller.ts:63</a></li>
+									<li>Defined in <a href="https://github.com/open-olive/loop-development-kit-node/blob/4a08e2f/src/controller.ts#L63">controller.ts:63</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -171,7 +171,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/open-olive/loop-development-kit-node/blob/843e171/src/controller.ts#L51">controller.ts:51</a></li>
+									<li>Defined in <a href="https://github.com/open-olive/loop-development-kit-node/blob/4a08e2f/src/controller.ts#L51">controller.ts:51</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -203,7 +203,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/open-olive/loop-development-kit-node/blob/843e171/src/controller.ts#L56">controller.ts:56</a></li>
+									<li>Defined in <a href="https://github.com/open-olive/loop-development-kit-node/blob/4a08e2f/src/controller.ts#L56">controller.ts:56</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">

--- a/docs/interfaces/controller.html
+++ b/docs/interfaces/controller.html
@@ -141,7 +141,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/open-olive/loop-development-kit-node/blob/fa2b79d/src/controller.ts#L63">controller.ts:63</a></li>
+									<li>Defined in <a href="https://github.com/open-olive/loop-development-kit-node/blob/843e171/src/controller.ts#L63">controller.ts:63</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -171,7 +171,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/open-olive/loop-development-kit-node/blob/fa2b79d/src/controller.ts#L51">controller.ts:51</a></li>
+									<li>Defined in <a href="https://github.com/open-olive/loop-development-kit-node/blob/843e171/src/controller.ts#L51">controller.ts:51</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -203,7 +203,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/open-olive/loop-development-kit-node/blob/fa2b79d/src/controller.ts#L56">controller.ts:56</a></li>
+									<li>Defined in <a href="https://github.com/open-olive/loop-development-kit-node/blob/843e171/src/controller.ts#L56">controller.ts:56</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">

--- a/docs/interfaces/controller.html
+++ b/docs/interfaces/controller.html
@@ -141,7 +141,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/open-olive/loop-development-kit-node/blob/52d7210/src/controller.ts#L63">controller.ts:63</a></li>
+									<li>Defined in <a href="https://github.com/open-olive/loop-development-kit-node/blob/fa2b79d/src/controller.ts#L63">controller.ts:63</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -171,7 +171,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/open-olive/loop-development-kit-node/blob/52d7210/src/controller.ts#L51">controller.ts:51</a></li>
+									<li>Defined in <a href="https://github.com/open-olive/loop-development-kit-node/blob/fa2b79d/src/controller.ts#L51">controller.ts:51</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -203,7 +203,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/open-olive/loop-development-kit-node/blob/52d7210/src/controller.ts#L56">controller.ts:56</a></li>
+									<li>Defined in <a href="https://github.com/open-olive/loop-development-kit-node/blob/fa2b79d/src/controller.ts#L56">controller.ts:56</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">

--- a/docs/interfaces/controller.html
+++ b/docs/interfaces/controller.html
@@ -141,7 +141,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/open-olive/loop-development-kit-node/blob/4a08e2f/src/controller.ts#L63">controller.ts:63</a></li>
+									<li>Defined in <a href="https://github.com/open-olive/loop-development-kit-node/blob/2576fcd/src/controller.ts#L63">controller.ts:63</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -171,7 +171,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/open-olive/loop-development-kit-node/blob/4a08e2f/src/controller.ts#L51">controller.ts:51</a></li>
+									<li>Defined in <a href="https://github.com/open-olive/loop-development-kit-node/blob/2576fcd/src/controller.ts#L51">controller.ts:51</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -203,7 +203,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/open-olive/loop-development-kit-node/blob/4a08e2f/src/controller.ts#L56">controller.ts:56</a></li>
+									<li>Defined in <a href="https://github.com/open-olive/loop-development-kit-node/blob/2576fcd/src/controller.ts#L56">controller.ts:56</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">

--- a/docs/interfaces/controllerhost.html
+++ b/docs/interfaces/controllerhost.html
@@ -111,7 +111,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/open-olive/loop-development-kit-node/blob/4a08e2f/src/controllerHost.ts#L8">controllerHost.ts:8</a></li>
+									<li>Defined in <a href="https://github.com/open-olive/loop-development-kit-node/blob/2576fcd/src/controllerHost.ts#L8">controllerHost.ts:8</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -140,7 +140,7 @@
 							<aside class="tsd-sources">
 								<p>Inherited from <a href="pluginhost.html">PluginHost</a>.<a href="pluginhost.html#storagedelete">storageDelete</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/open-olive/loop-development-kit-node/blob/4a08e2f/src/pluginHost.ts#L6">pluginHost.ts:6</a></li>
+									<li>Defined in <a href="https://github.com/open-olive/loop-development-kit-node/blob/2576fcd/src/pluginHost.ts#L6">pluginHost.ts:6</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -170,7 +170,7 @@
 							<aside class="tsd-sources">
 								<p>Inherited from <a href="pluginhost.html">PluginHost</a>.<a href="pluginhost.html#storagedeleteall">storageDeleteAll</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/open-olive/loop-development-kit-node/blob/4a08e2f/src/pluginHost.ts#L11">pluginHost.ts:11</a></li>
+									<li>Defined in <a href="https://github.com/open-olive/loop-development-kit-node/blob/2576fcd/src/pluginHost.ts#L11">pluginHost.ts:11</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -191,7 +191,7 @@
 							<aside class="tsd-sources">
 								<p>Inherited from <a href="pluginhost.html">PluginHost</a>.<a href="pluginhost.html#storagehaskey">storageHasKey</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/open-olive/loop-development-kit-node/blob/4a08e2f/src/pluginHost.ts#L17">pluginHost.ts:17</a></li>
+									<li>Defined in <a href="https://github.com/open-olive/loop-development-kit-node/blob/2576fcd/src/pluginHost.ts#L17">pluginHost.ts:17</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -221,7 +221,7 @@
 							<aside class="tsd-sources">
 								<p>Inherited from <a href="pluginhost.html">PluginHost</a>.<a href="pluginhost.html#storagekeys">storageKeys</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/open-olive/loop-development-kit-node/blob/4a08e2f/src/pluginHost.ts#L22">pluginHost.ts:22</a></li>
+									<li>Defined in <a href="https://github.com/open-olive/loop-development-kit-node/blob/2576fcd/src/pluginHost.ts#L22">pluginHost.ts:22</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -242,7 +242,7 @@
 							<aside class="tsd-sources">
 								<p>Inherited from <a href="pluginhost.html">PluginHost</a>.<a href="pluginhost.html#storageread">storageRead</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/open-olive/loop-development-kit-node/blob/4a08e2f/src/pluginHost.ts#L30">pluginHost.ts:30</a></li>
+									<li>Defined in <a href="https://github.com/open-olive/loop-development-kit-node/blob/2576fcd/src/pluginHost.ts#L30">pluginHost.ts:30</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -275,7 +275,7 @@
 							<aside class="tsd-sources">
 								<p>Inherited from <a href="pluginhost.html">PluginHost</a>.<a href="pluginhost.html#storagereadall">storageReadAll</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/open-olive/loop-development-kit-node/blob/4a08e2f/src/pluginHost.ts#L37">pluginHost.ts:37</a></li>
+									<li>Defined in <a href="https://github.com/open-olive/loop-development-kit-node/blob/2576fcd/src/pluginHost.ts#L37">pluginHost.ts:37</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -299,7 +299,7 @@
 							<aside class="tsd-sources">
 								<p>Inherited from <a href="pluginhost.html">PluginHost</a>.<a href="pluginhost.html#storagewrite">storageWrite</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/open-olive/loop-development-kit-node/blob/4a08e2f/src/pluginHost.ts#L46">pluginHost.ts:46</a></li>
+									<li>Defined in <a href="https://github.com/open-olive/loop-development-kit-node/blob/2576fcd/src/pluginHost.ts#L46">pluginHost.ts:46</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -337,7 +337,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/open-olive/loop-development-kit-node/blob/4a08e2f/src/controllerHost.ts#L9">controllerHost.ts:9</a></li>
+									<li>Defined in <a href="https://github.com/open-olive/loop-development-kit-node/blob/2576fcd/src/controllerHost.ts#L9">controllerHost.ts:9</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>

--- a/docs/interfaces/controllerhost.html
+++ b/docs/interfaces/controllerhost.html
@@ -111,7 +111,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/open-olive/loop-development-kit-node/blob/fa2b79d/src/controllerHost.ts#L8">controllerHost.ts:8</a></li>
+									<li>Defined in <a href="https://github.com/open-olive/loop-development-kit-node/blob/843e171/src/controllerHost.ts#L8">controllerHost.ts:8</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -140,7 +140,7 @@
 							<aside class="tsd-sources">
 								<p>Inherited from <a href="pluginhost.html">PluginHost</a>.<a href="pluginhost.html#storagedelete">storageDelete</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/open-olive/loop-development-kit-node/blob/fa2b79d/src/pluginHost.ts#L6">pluginHost.ts:6</a></li>
+									<li>Defined in <a href="https://github.com/open-olive/loop-development-kit-node/blob/843e171/src/pluginHost.ts#L6">pluginHost.ts:6</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -170,7 +170,7 @@
 							<aside class="tsd-sources">
 								<p>Inherited from <a href="pluginhost.html">PluginHost</a>.<a href="pluginhost.html#storagedeleteall">storageDeleteAll</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/open-olive/loop-development-kit-node/blob/fa2b79d/src/pluginHost.ts#L11">pluginHost.ts:11</a></li>
+									<li>Defined in <a href="https://github.com/open-olive/loop-development-kit-node/blob/843e171/src/pluginHost.ts#L11">pluginHost.ts:11</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -191,7 +191,7 @@
 							<aside class="tsd-sources">
 								<p>Inherited from <a href="pluginhost.html">PluginHost</a>.<a href="pluginhost.html#storagehaskey">storageHasKey</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/open-olive/loop-development-kit-node/blob/fa2b79d/src/pluginHost.ts#L17">pluginHost.ts:17</a></li>
+									<li>Defined in <a href="https://github.com/open-olive/loop-development-kit-node/blob/843e171/src/pluginHost.ts#L17">pluginHost.ts:17</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -221,7 +221,7 @@
 							<aside class="tsd-sources">
 								<p>Inherited from <a href="pluginhost.html">PluginHost</a>.<a href="pluginhost.html#storagekeys">storageKeys</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/open-olive/loop-development-kit-node/blob/fa2b79d/src/pluginHost.ts#L22">pluginHost.ts:22</a></li>
+									<li>Defined in <a href="https://github.com/open-olive/loop-development-kit-node/blob/843e171/src/pluginHost.ts#L22">pluginHost.ts:22</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -242,7 +242,7 @@
 							<aside class="tsd-sources">
 								<p>Inherited from <a href="pluginhost.html">PluginHost</a>.<a href="pluginhost.html#storageread">storageRead</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/open-olive/loop-development-kit-node/blob/fa2b79d/src/pluginHost.ts#L30">pluginHost.ts:30</a></li>
+									<li>Defined in <a href="https://github.com/open-olive/loop-development-kit-node/blob/843e171/src/pluginHost.ts#L30">pluginHost.ts:30</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -275,7 +275,7 @@
 							<aside class="tsd-sources">
 								<p>Inherited from <a href="pluginhost.html">PluginHost</a>.<a href="pluginhost.html#storagereadall">storageReadAll</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/open-olive/loop-development-kit-node/blob/fa2b79d/src/pluginHost.ts#L37">pluginHost.ts:37</a></li>
+									<li>Defined in <a href="https://github.com/open-olive/loop-development-kit-node/blob/843e171/src/pluginHost.ts#L37">pluginHost.ts:37</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -299,7 +299,7 @@
 							<aside class="tsd-sources">
 								<p>Inherited from <a href="pluginhost.html">PluginHost</a>.<a href="pluginhost.html#storagewrite">storageWrite</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/open-olive/loop-development-kit-node/blob/fa2b79d/src/pluginHost.ts#L46">pluginHost.ts:46</a></li>
+									<li>Defined in <a href="https://github.com/open-olive/loop-development-kit-node/blob/843e171/src/pluginHost.ts#L46">pluginHost.ts:46</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -337,7 +337,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/open-olive/loop-development-kit-node/blob/fa2b79d/src/controllerHost.ts#L9">controllerHost.ts:9</a></li>
+									<li>Defined in <a href="https://github.com/open-olive/loop-development-kit-node/blob/843e171/src/controllerHost.ts#L9">controllerHost.ts:9</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>

--- a/docs/interfaces/controllerhost.html
+++ b/docs/interfaces/controllerhost.html
@@ -111,7 +111,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/open-olive/loop-development-kit-node/blob/843e171/src/controllerHost.ts#L8">controllerHost.ts:8</a></li>
+									<li>Defined in <a href="https://github.com/open-olive/loop-development-kit-node/blob/4a08e2f/src/controllerHost.ts#L8">controllerHost.ts:8</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -140,7 +140,7 @@
 							<aside class="tsd-sources">
 								<p>Inherited from <a href="pluginhost.html">PluginHost</a>.<a href="pluginhost.html#storagedelete">storageDelete</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/open-olive/loop-development-kit-node/blob/843e171/src/pluginHost.ts#L6">pluginHost.ts:6</a></li>
+									<li>Defined in <a href="https://github.com/open-olive/loop-development-kit-node/blob/4a08e2f/src/pluginHost.ts#L6">pluginHost.ts:6</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -170,7 +170,7 @@
 							<aside class="tsd-sources">
 								<p>Inherited from <a href="pluginhost.html">PluginHost</a>.<a href="pluginhost.html#storagedeleteall">storageDeleteAll</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/open-olive/loop-development-kit-node/blob/843e171/src/pluginHost.ts#L11">pluginHost.ts:11</a></li>
+									<li>Defined in <a href="https://github.com/open-olive/loop-development-kit-node/blob/4a08e2f/src/pluginHost.ts#L11">pluginHost.ts:11</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -191,7 +191,7 @@
 							<aside class="tsd-sources">
 								<p>Inherited from <a href="pluginhost.html">PluginHost</a>.<a href="pluginhost.html#storagehaskey">storageHasKey</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/open-olive/loop-development-kit-node/blob/843e171/src/pluginHost.ts#L17">pluginHost.ts:17</a></li>
+									<li>Defined in <a href="https://github.com/open-olive/loop-development-kit-node/blob/4a08e2f/src/pluginHost.ts#L17">pluginHost.ts:17</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -221,7 +221,7 @@
 							<aside class="tsd-sources">
 								<p>Inherited from <a href="pluginhost.html">PluginHost</a>.<a href="pluginhost.html#storagekeys">storageKeys</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/open-olive/loop-development-kit-node/blob/843e171/src/pluginHost.ts#L22">pluginHost.ts:22</a></li>
+									<li>Defined in <a href="https://github.com/open-olive/loop-development-kit-node/blob/4a08e2f/src/pluginHost.ts#L22">pluginHost.ts:22</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -242,7 +242,7 @@
 							<aside class="tsd-sources">
 								<p>Inherited from <a href="pluginhost.html">PluginHost</a>.<a href="pluginhost.html#storageread">storageRead</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/open-olive/loop-development-kit-node/blob/843e171/src/pluginHost.ts#L30">pluginHost.ts:30</a></li>
+									<li>Defined in <a href="https://github.com/open-olive/loop-development-kit-node/blob/4a08e2f/src/pluginHost.ts#L30">pluginHost.ts:30</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -275,7 +275,7 @@
 							<aside class="tsd-sources">
 								<p>Inherited from <a href="pluginhost.html">PluginHost</a>.<a href="pluginhost.html#storagereadall">storageReadAll</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/open-olive/loop-development-kit-node/blob/843e171/src/pluginHost.ts#L37">pluginHost.ts:37</a></li>
+									<li>Defined in <a href="https://github.com/open-olive/loop-development-kit-node/blob/4a08e2f/src/pluginHost.ts#L37">pluginHost.ts:37</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -299,7 +299,7 @@
 							<aside class="tsd-sources">
 								<p>Inherited from <a href="pluginhost.html">PluginHost</a>.<a href="pluginhost.html#storagewrite">storageWrite</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/open-olive/loop-development-kit-node/blob/843e171/src/pluginHost.ts#L46">pluginHost.ts:46</a></li>
+									<li>Defined in <a href="https://github.com/open-olive/loop-development-kit-node/blob/4a08e2f/src/pluginHost.ts#L46">pluginHost.ts:46</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -337,7 +337,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/open-olive/loop-development-kit-node/blob/843e171/src/controllerHost.ts#L9">controllerHost.ts:9</a></li>
+									<li>Defined in <a href="https://github.com/open-olive/loop-development-kit-node/blob/4a08e2f/src/controllerHost.ts#L9">controllerHost.ts:9</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>

--- a/docs/interfaces/controllerhost.html
+++ b/docs/interfaces/controllerhost.html
@@ -111,7 +111,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/open-olive/loop-development-kit-node/blob/52d7210/src/controllerHost.ts#L8">controllerHost.ts:8</a></li>
+									<li>Defined in <a href="https://github.com/open-olive/loop-development-kit-node/blob/fa2b79d/src/controllerHost.ts#L8">controllerHost.ts:8</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -140,7 +140,7 @@
 							<aside class="tsd-sources">
 								<p>Inherited from <a href="pluginhost.html">PluginHost</a>.<a href="pluginhost.html#storagedelete">storageDelete</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/open-olive/loop-development-kit-node/blob/52d7210/src/pluginHost.ts#L6">pluginHost.ts:6</a></li>
+									<li>Defined in <a href="https://github.com/open-olive/loop-development-kit-node/blob/fa2b79d/src/pluginHost.ts#L6">pluginHost.ts:6</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -170,7 +170,7 @@
 							<aside class="tsd-sources">
 								<p>Inherited from <a href="pluginhost.html">PluginHost</a>.<a href="pluginhost.html#storagedeleteall">storageDeleteAll</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/open-olive/loop-development-kit-node/blob/52d7210/src/pluginHost.ts#L11">pluginHost.ts:11</a></li>
+									<li>Defined in <a href="https://github.com/open-olive/loop-development-kit-node/blob/fa2b79d/src/pluginHost.ts#L11">pluginHost.ts:11</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -191,7 +191,7 @@
 							<aside class="tsd-sources">
 								<p>Inherited from <a href="pluginhost.html">PluginHost</a>.<a href="pluginhost.html#storagehaskey">storageHasKey</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/open-olive/loop-development-kit-node/blob/52d7210/src/pluginHost.ts#L17">pluginHost.ts:17</a></li>
+									<li>Defined in <a href="https://github.com/open-olive/loop-development-kit-node/blob/fa2b79d/src/pluginHost.ts#L17">pluginHost.ts:17</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -221,7 +221,7 @@
 							<aside class="tsd-sources">
 								<p>Inherited from <a href="pluginhost.html">PluginHost</a>.<a href="pluginhost.html#storagekeys">storageKeys</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/open-olive/loop-development-kit-node/blob/52d7210/src/pluginHost.ts#L22">pluginHost.ts:22</a></li>
+									<li>Defined in <a href="https://github.com/open-olive/loop-development-kit-node/blob/fa2b79d/src/pluginHost.ts#L22">pluginHost.ts:22</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -242,7 +242,7 @@
 							<aside class="tsd-sources">
 								<p>Inherited from <a href="pluginhost.html">PluginHost</a>.<a href="pluginhost.html#storageread">storageRead</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/open-olive/loop-development-kit-node/blob/52d7210/src/pluginHost.ts#L30">pluginHost.ts:30</a></li>
+									<li>Defined in <a href="https://github.com/open-olive/loop-development-kit-node/blob/fa2b79d/src/pluginHost.ts#L30">pluginHost.ts:30</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -275,7 +275,7 @@
 							<aside class="tsd-sources">
 								<p>Inherited from <a href="pluginhost.html">PluginHost</a>.<a href="pluginhost.html#storagereadall">storageReadAll</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/open-olive/loop-development-kit-node/blob/52d7210/src/pluginHost.ts#L37">pluginHost.ts:37</a></li>
+									<li>Defined in <a href="https://github.com/open-olive/loop-development-kit-node/blob/fa2b79d/src/pluginHost.ts#L37">pluginHost.ts:37</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -299,7 +299,7 @@
 							<aside class="tsd-sources">
 								<p>Inherited from <a href="pluginhost.html">PluginHost</a>.<a href="pluginhost.html#storagewrite">storageWrite</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/open-olive/loop-development-kit-node/blob/52d7210/src/pluginHost.ts#L46">pluginHost.ts:46</a></li>
+									<li>Defined in <a href="https://github.com/open-olive/loop-development-kit-node/blob/fa2b79d/src/pluginHost.ts#L46">pluginHost.ts:46</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -337,7 +337,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/open-olive/loop-development-kit-node/blob/52d7210/src/controllerHost.ts#L9">controllerHost.ts:9</a></li>
+									<li>Defined in <a href="https://github.com/open-olive/loop-development-kit-node/blob/fa2b79d/src/controllerHost.ts#L9">controllerHost.ts:9</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>

--- a/docs/interfaces/pluginevent.html
+++ b/docs/interfaces/pluginevent.html
@@ -101,7 +101,7 @@
 					<div class="tsd-signature tsd-kind-icon">data<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-symbol">{}</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/open-olive/loop-development-kit-node/blob/4a08e2f/src/pluginEvent.ts#L6">pluginEvent.ts:6</a></li>
+							<li>Defined in <a href="https://github.com/open-olive/loop-development-kit-node/blob/2576fcd/src/pluginEvent.ts#L6">pluginEvent.ts:6</a></li>
 						</ul>
 					</aside>
 					<div class="tsd-type-declaration">

--- a/docs/interfaces/pluginevent.html
+++ b/docs/interfaces/pluginevent.html
@@ -101,7 +101,7 @@
 					<div class="tsd-signature tsd-kind-icon">data<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-symbol">{}</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/open-olive/loop-development-kit-node/blob/843e171/src/pluginEvent.ts#L6">pluginEvent.ts:6</a></li>
+							<li>Defined in <a href="https://github.com/open-olive/loop-development-kit-node/blob/4a08e2f/src/pluginEvent.ts#L6">pluginEvent.ts:6</a></li>
 						</ul>
 					</aside>
 					<div class="tsd-type-declaration">

--- a/docs/interfaces/pluginevent.html
+++ b/docs/interfaces/pluginevent.html
@@ -101,7 +101,7 @@
 					<div class="tsd-signature tsd-kind-icon">data<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-symbol">{}</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/open-olive/loop-development-kit-node/blob/fa2b79d/src/pluginEvent.ts#L6">pluginEvent.ts:6</a></li>
+							<li>Defined in <a href="https://github.com/open-olive/loop-development-kit-node/blob/843e171/src/pluginEvent.ts#L6">pluginEvent.ts:6</a></li>
 						</ul>
 					</aside>
 					<div class="tsd-type-declaration">

--- a/docs/interfaces/pluginevent.html
+++ b/docs/interfaces/pluginevent.html
@@ -101,7 +101,7 @@
 					<div class="tsd-signature tsd-kind-icon">data<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-symbol">{}</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/open-olive/loop-development-kit-node/blob/52d7210/src/pluginEvent.ts#L6">pluginEvent.ts:6</a></li>
+							<li>Defined in <a href="https://github.com/open-olive/loop-development-kit-node/blob/fa2b79d/src/pluginEvent.ts#L6">pluginEvent.ts:6</a></li>
 						</ul>
 					</aside>
 					<div class="tsd-type-declaration">

--- a/docs/interfaces/pluginhost.html
+++ b/docs/interfaces/pluginhost.html
@@ -112,7 +112,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/open-olive/loop-development-kit-node/blob/843e171/src/pluginHost.ts#L6">pluginHost.ts:6</a></li>
+									<li>Defined in <a href="https://github.com/open-olive/loop-development-kit-node/blob/4a08e2f/src/pluginHost.ts#L6">pluginHost.ts:6</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -141,7 +141,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/open-olive/loop-development-kit-node/blob/843e171/src/pluginHost.ts#L11">pluginHost.ts:11</a></li>
+									<li>Defined in <a href="https://github.com/open-olive/loop-development-kit-node/blob/4a08e2f/src/pluginHost.ts#L11">pluginHost.ts:11</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -161,7 +161,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/open-olive/loop-development-kit-node/blob/843e171/src/pluginHost.ts#L17">pluginHost.ts:17</a></li>
+									<li>Defined in <a href="https://github.com/open-olive/loop-development-kit-node/blob/4a08e2f/src/pluginHost.ts#L17">pluginHost.ts:17</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -190,7 +190,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/open-olive/loop-development-kit-node/blob/843e171/src/pluginHost.ts#L22">pluginHost.ts:22</a></li>
+									<li>Defined in <a href="https://github.com/open-olive/loop-development-kit-node/blob/4a08e2f/src/pluginHost.ts#L22">pluginHost.ts:22</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -210,7 +210,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/open-olive/loop-development-kit-node/blob/843e171/src/pluginHost.ts#L30">pluginHost.ts:30</a></li>
+									<li>Defined in <a href="https://github.com/open-olive/loop-development-kit-node/blob/4a08e2f/src/pluginHost.ts#L30">pluginHost.ts:30</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -242,7 +242,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/open-olive/loop-development-kit-node/blob/843e171/src/pluginHost.ts#L37">pluginHost.ts:37</a></li>
+									<li>Defined in <a href="https://github.com/open-olive/loop-development-kit-node/blob/4a08e2f/src/pluginHost.ts#L37">pluginHost.ts:37</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -265,7 +265,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/open-olive/loop-development-kit-node/blob/843e171/src/pluginHost.ts#L46">pluginHost.ts:46</a></li>
+									<li>Defined in <a href="https://github.com/open-olive/loop-development-kit-node/blob/4a08e2f/src/pluginHost.ts#L46">pluginHost.ts:46</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">

--- a/docs/interfaces/pluginhost.html
+++ b/docs/interfaces/pluginhost.html
@@ -112,7 +112,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/open-olive/loop-development-kit-node/blob/52d7210/src/pluginHost.ts#L6">pluginHost.ts:6</a></li>
+									<li>Defined in <a href="https://github.com/open-olive/loop-development-kit-node/blob/fa2b79d/src/pluginHost.ts#L6">pluginHost.ts:6</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -141,7 +141,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/open-olive/loop-development-kit-node/blob/52d7210/src/pluginHost.ts#L11">pluginHost.ts:11</a></li>
+									<li>Defined in <a href="https://github.com/open-olive/loop-development-kit-node/blob/fa2b79d/src/pluginHost.ts#L11">pluginHost.ts:11</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -161,7 +161,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/open-olive/loop-development-kit-node/blob/52d7210/src/pluginHost.ts#L17">pluginHost.ts:17</a></li>
+									<li>Defined in <a href="https://github.com/open-olive/loop-development-kit-node/blob/fa2b79d/src/pluginHost.ts#L17">pluginHost.ts:17</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -190,7 +190,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/open-olive/loop-development-kit-node/blob/52d7210/src/pluginHost.ts#L22">pluginHost.ts:22</a></li>
+									<li>Defined in <a href="https://github.com/open-olive/loop-development-kit-node/blob/fa2b79d/src/pluginHost.ts#L22">pluginHost.ts:22</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -210,7 +210,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/open-olive/loop-development-kit-node/blob/52d7210/src/pluginHost.ts#L30">pluginHost.ts:30</a></li>
+									<li>Defined in <a href="https://github.com/open-olive/loop-development-kit-node/blob/fa2b79d/src/pluginHost.ts#L30">pluginHost.ts:30</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -242,7 +242,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/open-olive/loop-development-kit-node/blob/52d7210/src/pluginHost.ts#L37">pluginHost.ts:37</a></li>
+									<li>Defined in <a href="https://github.com/open-olive/loop-development-kit-node/blob/fa2b79d/src/pluginHost.ts#L37">pluginHost.ts:37</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -265,7 +265,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/open-olive/loop-development-kit-node/blob/52d7210/src/pluginHost.ts#L46">pluginHost.ts:46</a></li>
+									<li>Defined in <a href="https://github.com/open-olive/loop-development-kit-node/blob/fa2b79d/src/pluginHost.ts#L46">pluginHost.ts:46</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">

--- a/docs/interfaces/pluginhost.html
+++ b/docs/interfaces/pluginhost.html
@@ -112,7 +112,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/open-olive/loop-development-kit-node/blob/fa2b79d/src/pluginHost.ts#L6">pluginHost.ts:6</a></li>
+									<li>Defined in <a href="https://github.com/open-olive/loop-development-kit-node/blob/843e171/src/pluginHost.ts#L6">pluginHost.ts:6</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -141,7 +141,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/open-olive/loop-development-kit-node/blob/fa2b79d/src/pluginHost.ts#L11">pluginHost.ts:11</a></li>
+									<li>Defined in <a href="https://github.com/open-olive/loop-development-kit-node/blob/843e171/src/pluginHost.ts#L11">pluginHost.ts:11</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -161,7 +161,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/open-olive/loop-development-kit-node/blob/fa2b79d/src/pluginHost.ts#L17">pluginHost.ts:17</a></li>
+									<li>Defined in <a href="https://github.com/open-olive/loop-development-kit-node/blob/843e171/src/pluginHost.ts#L17">pluginHost.ts:17</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -190,7 +190,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/open-olive/loop-development-kit-node/blob/fa2b79d/src/pluginHost.ts#L22">pluginHost.ts:22</a></li>
+									<li>Defined in <a href="https://github.com/open-olive/loop-development-kit-node/blob/843e171/src/pluginHost.ts#L22">pluginHost.ts:22</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -210,7 +210,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/open-olive/loop-development-kit-node/blob/fa2b79d/src/pluginHost.ts#L30">pluginHost.ts:30</a></li>
+									<li>Defined in <a href="https://github.com/open-olive/loop-development-kit-node/blob/843e171/src/pluginHost.ts#L30">pluginHost.ts:30</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -242,7 +242,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/open-olive/loop-development-kit-node/blob/fa2b79d/src/pluginHost.ts#L37">pluginHost.ts:37</a></li>
+									<li>Defined in <a href="https://github.com/open-olive/loop-development-kit-node/blob/843e171/src/pluginHost.ts#L37">pluginHost.ts:37</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -265,7 +265,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/open-olive/loop-development-kit-node/blob/fa2b79d/src/pluginHost.ts#L46">pluginHost.ts:46</a></li>
+									<li>Defined in <a href="https://github.com/open-olive/loop-development-kit-node/blob/843e171/src/pluginHost.ts#L46">pluginHost.ts:46</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">

--- a/docs/interfaces/pluginhost.html
+++ b/docs/interfaces/pluginhost.html
@@ -112,7 +112,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/open-olive/loop-development-kit-node/blob/4a08e2f/src/pluginHost.ts#L6">pluginHost.ts:6</a></li>
+									<li>Defined in <a href="https://github.com/open-olive/loop-development-kit-node/blob/2576fcd/src/pluginHost.ts#L6">pluginHost.ts:6</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -141,7 +141,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/open-olive/loop-development-kit-node/blob/4a08e2f/src/pluginHost.ts#L11">pluginHost.ts:11</a></li>
+									<li>Defined in <a href="https://github.com/open-olive/loop-development-kit-node/blob/2576fcd/src/pluginHost.ts#L11">pluginHost.ts:11</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -161,7 +161,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/open-olive/loop-development-kit-node/blob/4a08e2f/src/pluginHost.ts#L17">pluginHost.ts:17</a></li>
+									<li>Defined in <a href="https://github.com/open-olive/loop-development-kit-node/blob/2576fcd/src/pluginHost.ts#L17">pluginHost.ts:17</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -190,7 +190,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/open-olive/loop-development-kit-node/blob/4a08e2f/src/pluginHost.ts#L22">pluginHost.ts:22</a></li>
+									<li>Defined in <a href="https://github.com/open-olive/loop-development-kit-node/blob/2576fcd/src/pluginHost.ts#L22">pluginHost.ts:22</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -210,7 +210,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/open-olive/loop-development-kit-node/blob/4a08e2f/src/pluginHost.ts#L30">pluginHost.ts:30</a></li>
+									<li>Defined in <a href="https://github.com/open-olive/loop-development-kit-node/blob/2576fcd/src/pluginHost.ts#L30">pluginHost.ts:30</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -242,7 +242,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/open-olive/loop-development-kit-node/blob/4a08e2f/src/pluginHost.ts#L37">pluginHost.ts:37</a></li>
+									<li>Defined in <a href="https://github.com/open-olive/loop-development-kit-node/blob/2576fcd/src/pluginHost.ts#L37">pluginHost.ts:37</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -265,7 +265,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/open-olive/loop-development-kit-node/blob/4a08e2f/src/pluginHost.ts#L46">pluginHost.ts:46</a></li>
+									<li>Defined in <a href="https://github.com/open-olive/loop-development-kit-node/blob/2576fcd/src/pluginHost.ts#L46">pluginHost.ts:46</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">

--- a/docs/interfaces/sensor.html
+++ b/docs/interfaces/sensor.html
@@ -138,7 +138,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/open-olive/loop-development-kit-node/blob/52d7210/src/sensor.ts#L60">sensor.ts:60</a></li>
+									<li>Defined in <a href="https://github.com/open-olive/loop-development-kit-node/blob/fa2b79d/src/sensor.ts#L60">sensor.ts:60</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -169,7 +169,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/open-olive/loop-development-kit-node/blob/52d7210/src/sensor.ts#L48">sensor.ts:48</a></li>
+									<li>Defined in <a href="https://github.com/open-olive/loop-development-kit-node/blob/fa2b79d/src/sensor.ts#L48">sensor.ts:48</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -200,7 +200,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/open-olive/loop-development-kit-node/blob/52d7210/src/sensor.ts#L53">sensor.ts:53</a></li>
+									<li>Defined in <a href="https://github.com/open-olive/loop-development-kit-node/blob/fa2b79d/src/sensor.ts#L53">sensor.ts:53</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">

--- a/docs/interfaces/sensor.html
+++ b/docs/interfaces/sensor.html
@@ -138,7 +138,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/open-olive/loop-development-kit-node/blob/843e171/src/sensor.ts#L60">sensor.ts:60</a></li>
+									<li>Defined in <a href="https://github.com/open-olive/loop-development-kit-node/blob/4a08e2f/src/sensor.ts#L60">sensor.ts:60</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -169,7 +169,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/open-olive/loop-development-kit-node/blob/843e171/src/sensor.ts#L48">sensor.ts:48</a></li>
+									<li>Defined in <a href="https://github.com/open-olive/loop-development-kit-node/blob/4a08e2f/src/sensor.ts#L48">sensor.ts:48</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -200,7 +200,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/open-olive/loop-development-kit-node/blob/843e171/src/sensor.ts#L53">sensor.ts:53</a></li>
+									<li>Defined in <a href="https://github.com/open-olive/loop-development-kit-node/blob/4a08e2f/src/sensor.ts#L53">sensor.ts:53</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">

--- a/docs/interfaces/sensor.html
+++ b/docs/interfaces/sensor.html
@@ -138,7 +138,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/open-olive/loop-development-kit-node/blob/fa2b79d/src/sensor.ts#L60">sensor.ts:60</a></li>
+									<li>Defined in <a href="https://github.com/open-olive/loop-development-kit-node/blob/843e171/src/sensor.ts#L60">sensor.ts:60</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -169,7 +169,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/open-olive/loop-development-kit-node/blob/fa2b79d/src/sensor.ts#L48">sensor.ts:48</a></li>
+									<li>Defined in <a href="https://github.com/open-olive/loop-development-kit-node/blob/843e171/src/sensor.ts#L48">sensor.ts:48</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -200,7 +200,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/open-olive/loop-development-kit-node/blob/fa2b79d/src/sensor.ts#L53">sensor.ts:53</a></li>
+									<li>Defined in <a href="https://github.com/open-olive/loop-development-kit-node/blob/843e171/src/sensor.ts#L53">sensor.ts:53</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">

--- a/docs/interfaces/sensor.html
+++ b/docs/interfaces/sensor.html
@@ -138,7 +138,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/open-olive/loop-development-kit-node/blob/4a08e2f/src/sensor.ts#L60">sensor.ts:60</a></li>
+									<li>Defined in <a href="https://github.com/open-olive/loop-development-kit-node/blob/2576fcd/src/sensor.ts#L60">sensor.ts:60</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -169,7 +169,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/open-olive/loop-development-kit-node/blob/4a08e2f/src/sensor.ts#L48">sensor.ts:48</a></li>
+									<li>Defined in <a href="https://github.com/open-olive/loop-development-kit-node/blob/2576fcd/src/sensor.ts#L48">sensor.ts:48</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -200,7 +200,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/open-olive/loop-development-kit-node/blob/4a08e2f/src/sensor.ts#L53">sensor.ts:53</a></li>
+									<li>Defined in <a href="https://github.com/open-olive/loop-development-kit-node/blob/2576fcd/src/sensor.ts#L53">sensor.ts:53</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">

--- a/docs/interfaces/sensorhost.html
+++ b/docs/interfaces/sensorhost.html
@@ -110,7 +110,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/open-olive/loop-development-kit-node/blob/843e171/src/sensorHost.ts#L10">sensorHost.ts:10</a></li>
+									<li>Defined in <a href="https://github.com/open-olive/loop-development-kit-node/blob/4a08e2f/src/sensorHost.ts#L10">sensorHost.ts:10</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -142,7 +142,7 @@
 							<aside class="tsd-sources">
 								<p>Inherited from <a href="pluginhost.html">PluginHost</a>.<a href="pluginhost.html#storagedelete">storageDelete</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/open-olive/loop-development-kit-node/blob/843e171/src/pluginHost.ts#L6">pluginHost.ts:6</a></li>
+									<li>Defined in <a href="https://github.com/open-olive/loop-development-kit-node/blob/4a08e2f/src/pluginHost.ts#L6">pluginHost.ts:6</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -172,7 +172,7 @@
 							<aside class="tsd-sources">
 								<p>Inherited from <a href="pluginhost.html">PluginHost</a>.<a href="pluginhost.html#storagedeleteall">storageDeleteAll</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/open-olive/loop-development-kit-node/blob/843e171/src/pluginHost.ts#L11">pluginHost.ts:11</a></li>
+									<li>Defined in <a href="https://github.com/open-olive/loop-development-kit-node/blob/4a08e2f/src/pluginHost.ts#L11">pluginHost.ts:11</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -193,7 +193,7 @@
 							<aside class="tsd-sources">
 								<p>Inherited from <a href="pluginhost.html">PluginHost</a>.<a href="pluginhost.html#storagehaskey">storageHasKey</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/open-olive/loop-development-kit-node/blob/843e171/src/pluginHost.ts#L17">pluginHost.ts:17</a></li>
+									<li>Defined in <a href="https://github.com/open-olive/loop-development-kit-node/blob/4a08e2f/src/pluginHost.ts#L17">pluginHost.ts:17</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -223,7 +223,7 @@
 							<aside class="tsd-sources">
 								<p>Inherited from <a href="pluginhost.html">PluginHost</a>.<a href="pluginhost.html#storagekeys">storageKeys</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/open-olive/loop-development-kit-node/blob/843e171/src/pluginHost.ts#L22">pluginHost.ts:22</a></li>
+									<li>Defined in <a href="https://github.com/open-olive/loop-development-kit-node/blob/4a08e2f/src/pluginHost.ts#L22">pluginHost.ts:22</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -244,7 +244,7 @@
 							<aside class="tsd-sources">
 								<p>Inherited from <a href="pluginhost.html">PluginHost</a>.<a href="pluginhost.html#storageread">storageRead</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/open-olive/loop-development-kit-node/blob/843e171/src/pluginHost.ts#L30">pluginHost.ts:30</a></li>
+									<li>Defined in <a href="https://github.com/open-olive/loop-development-kit-node/blob/4a08e2f/src/pluginHost.ts#L30">pluginHost.ts:30</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -277,7 +277,7 @@
 							<aside class="tsd-sources">
 								<p>Inherited from <a href="pluginhost.html">PluginHost</a>.<a href="pluginhost.html#storagereadall">storageReadAll</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/open-olive/loop-development-kit-node/blob/843e171/src/pluginHost.ts#L37">pluginHost.ts:37</a></li>
+									<li>Defined in <a href="https://github.com/open-olive/loop-development-kit-node/blob/4a08e2f/src/pluginHost.ts#L37">pluginHost.ts:37</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -301,7 +301,7 @@
 							<aside class="tsd-sources">
 								<p>Inherited from <a href="pluginhost.html">PluginHost</a>.<a href="pluginhost.html#storagewrite">storageWrite</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/open-olive/loop-development-kit-node/blob/843e171/src/pluginHost.ts#L46">pluginHost.ts:46</a></li>
+									<li>Defined in <a href="https://github.com/open-olive/loop-development-kit-node/blob/4a08e2f/src/pluginHost.ts#L46">pluginHost.ts:46</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">

--- a/docs/interfaces/sensorhost.html
+++ b/docs/interfaces/sensorhost.html
@@ -110,7 +110,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/open-olive/loop-development-kit-node/blob/4a08e2f/src/sensorHost.ts#L10">sensorHost.ts:10</a></li>
+									<li>Defined in <a href="https://github.com/open-olive/loop-development-kit-node/blob/2576fcd/src/sensorHost.ts#L10">sensorHost.ts:10</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -142,7 +142,7 @@
 							<aside class="tsd-sources">
 								<p>Inherited from <a href="pluginhost.html">PluginHost</a>.<a href="pluginhost.html#storagedelete">storageDelete</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/open-olive/loop-development-kit-node/blob/4a08e2f/src/pluginHost.ts#L6">pluginHost.ts:6</a></li>
+									<li>Defined in <a href="https://github.com/open-olive/loop-development-kit-node/blob/2576fcd/src/pluginHost.ts#L6">pluginHost.ts:6</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -172,7 +172,7 @@
 							<aside class="tsd-sources">
 								<p>Inherited from <a href="pluginhost.html">PluginHost</a>.<a href="pluginhost.html#storagedeleteall">storageDeleteAll</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/open-olive/loop-development-kit-node/blob/4a08e2f/src/pluginHost.ts#L11">pluginHost.ts:11</a></li>
+									<li>Defined in <a href="https://github.com/open-olive/loop-development-kit-node/blob/2576fcd/src/pluginHost.ts#L11">pluginHost.ts:11</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -193,7 +193,7 @@
 							<aside class="tsd-sources">
 								<p>Inherited from <a href="pluginhost.html">PluginHost</a>.<a href="pluginhost.html#storagehaskey">storageHasKey</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/open-olive/loop-development-kit-node/blob/4a08e2f/src/pluginHost.ts#L17">pluginHost.ts:17</a></li>
+									<li>Defined in <a href="https://github.com/open-olive/loop-development-kit-node/blob/2576fcd/src/pluginHost.ts#L17">pluginHost.ts:17</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -223,7 +223,7 @@
 							<aside class="tsd-sources">
 								<p>Inherited from <a href="pluginhost.html">PluginHost</a>.<a href="pluginhost.html#storagekeys">storageKeys</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/open-olive/loop-development-kit-node/blob/4a08e2f/src/pluginHost.ts#L22">pluginHost.ts:22</a></li>
+									<li>Defined in <a href="https://github.com/open-olive/loop-development-kit-node/blob/2576fcd/src/pluginHost.ts#L22">pluginHost.ts:22</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -244,7 +244,7 @@
 							<aside class="tsd-sources">
 								<p>Inherited from <a href="pluginhost.html">PluginHost</a>.<a href="pluginhost.html#storageread">storageRead</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/open-olive/loop-development-kit-node/blob/4a08e2f/src/pluginHost.ts#L30">pluginHost.ts:30</a></li>
+									<li>Defined in <a href="https://github.com/open-olive/loop-development-kit-node/blob/2576fcd/src/pluginHost.ts#L30">pluginHost.ts:30</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -277,7 +277,7 @@
 							<aside class="tsd-sources">
 								<p>Inherited from <a href="pluginhost.html">PluginHost</a>.<a href="pluginhost.html#storagereadall">storageReadAll</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/open-olive/loop-development-kit-node/blob/4a08e2f/src/pluginHost.ts#L37">pluginHost.ts:37</a></li>
+									<li>Defined in <a href="https://github.com/open-olive/loop-development-kit-node/blob/2576fcd/src/pluginHost.ts#L37">pluginHost.ts:37</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -301,7 +301,7 @@
 							<aside class="tsd-sources">
 								<p>Inherited from <a href="pluginhost.html">PluginHost</a>.<a href="pluginhost.html#storagewrite">storageWrite</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/open-olive/loop-development-kit-node/blob/4a08e2f/src/pluginHost.ts#L46">pluginHost.ts:46</a></li>
+									<li>Defined in <a href="https://github.com/open-olive/loop-development-kit-node/blob/2576fcd/src/pluginHost.ts#L46">pluginHost.ts:46</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">

--- a/docs/interfaces/sensorhost.html
+++ b/docs/interfaces/sensorhost.html
@@ -110,7 +110,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/open-olive/loop-development-kit-node/blob/52d7210/src/sensorHost.ts#L10">sensorHost.ts:10</a></li>
+									<li>Defined in <a href="https://github.com/open-olive/loop-development-kit-node/blob/fa2b79d/src/sensorHost.ts#L10">sensorHost.ts:10</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -142,7 +142,7 @@
 							<aside class="tsd-sources">
 								<p>Inherited from <a href="pluginhost.html">PluginHost</a>.<a href="pluginhost.html#storagedelete">storageDelete</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/open-olive/loop-development-kit-node/blob/52d7210/src/pluginHost.ts#L6">pluginHost.ts:6</a></li>
+									<li>Defined in <a href="https://github.com/open-olive/loop-development-kit-node/blob/fa2b79d/src/pluginHost.ts#L6">pluginHost.ts:6</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -172,7 +172,7 @@
 							<aside class="tsd-sources">
 								<p>Inherited from <a href="pluginhost.html">PluginHost</a>.<a href="pluginhost.html#storagedeleteall">storageDeleteAll</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/open-olive/loop-development-kit-node/blob/52d7210/src/pluginHost.ts#L11">pluginHost.ts:11</a></li>
+									<li>Defined in <a href="https://github.com/open-olive/loop-development-kit-node/blob/fa2b79d/src/pluginHost.ts#L11">pluginHost.ts:11</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -193,7 +193,7 @@
 							<aside class="tsd-sources">
 								<p>Inherited from <a href="pluginhost.html">PluginHost</a>.<a href="pluginhost.html#storagehaskey">storageHasKey</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/open-olive/loop-development-kit-node/blob/52d7210/src/pluginHost.ts#L17">pluginHost.ts:17</a></li>
+									<li>Defined in <a href="https://github.com/open-olive/loop-development-kit-node/blob/fa2b79d/src/pluginHost.ts#L17">pluginHost.ts:17</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -223,7 +223,7 @@
 							<aside class="tsd-sources">
 								<p>Inherited from <a href="pluginhost.html">PluginHost</a>.<a href="pluginhost.html#storagekeys">storageKeys</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/open-olive/loop-development-kit-node/blob/52d7210/src/pluginHost.ts#L22">pluginHost.ts:22</a></li>
+									<li>Defined in <a href="https://github.com/open-olive/loop-development-kit-node/blob/fa2b79d/src/pluginHost.ts#L22">pluginHost.ts:22</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -244,7 +244,7 @@
 							<aside class="tsd-sources">
 								<p>Inherited from <a href="pluginhost.html">PluginHost</a>.<a href="pluginhost.html#storageread">storageRead</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/open-olive/loop-development-kit-node/blob/52d7210/src/pluginHost.ts#L30">pluginHost.ts:30</a></li>
+									<li>Defined in <a href="https://github.com/open-olive/loop-development-kit-node/blob/fa2b79d/src/pluginHost.ts#L30">pluginHost.ts:30</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -277,7 +277,7 @@
 							<aside class="tsd-sources">
 								<p>Inherited from <a href="pluginhost.html">PluginHost</a>.<a href="pluginhost.html#storagereadall">storageReadAll</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/open-olive/loop-development-kit-node/blob/52d7210/src/pluginHost.ts#L37">pluginHost.ts:37</a></li>
+									<li>Defined in <a href="https://github.com/open-olive/loop-development-kit-node/blob/fa2b79d/src/pluginHost.ts#L37">pluginHost.ts:37</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -301,7 +301,7 @@
 							<aside class="tsd-sources">
 								<p>Inherited from <a href="pluginhost.html">PluginHost</a>.<a href="pluginhost.html#storagewrite">storageWrite</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/open-olive/loop-development-kit-node/blob/52d7210/src/pluginHost.ts#L46">pluginHost.ts:46</a></li>
+									<li>Defined in <a href="https://github.com/open-olive/loop-development-kit-node/blob/fa2b79d/src/pluginHost.ts#L46">pluginHost.ts:46</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">

--- a/docs/interfaces/sensorhost.html
+++ b/docs/interfaces/sensorhost.html
@@ -110,7 +110,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/open-olive/loop-development-kit-node/blob/fa2b79d/src/sensorHost.ts#L10">sensorHost.ts:10</a></li>
+									<li>Defined in <a href="https://github.com/open-olive/loop-development-kit-node/blob/843e171/src/sensorHost.ts#L10">sensorHost.ts:10</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -142,7 +142,7 @@
 							<aside class="tsd-sources">
 								<p>Inherited from <a href="pluginhost.html">PluginHost</a>.<a href="pluginhost.html#storagedelete">storageDelete</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/open-olive/loop-development-kit-node/blob/fa2b79d/src/pluginHost.ts#L6">pluginHost.ts:6</a></li>
+									<li>Defined in <a href="https://github.com/open-olive/loop-development-kit-node/blob/843e171/src/pluginHost.ts#L6">pluginHost.ts:6</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -172,7 +172,7 @@
 							<aside class="tsd-sources">
 								<p>Inherited from <a href="pluginhost.html">PluginHost</a>.<a href="pluginhost.html#storagedeleteall">storageDeleteAll</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/open-olive/loop-development-kit-node/blob/fa2b79d/src/pluginHost.ts#L11">pluginHost.ts:11</a></li>
+									<li>Defined in <a href="https://github.com/open-olive/loop-development-kit-node/blob/843e171/src/pluginHost.ts#L11">pluginHost.ts:11</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -193,7 +193,7 @@
 							<aside class="tsd-sources">
 								<p>Inherited from <a href="pluginhost.html">PluginHost</a>.<a href="pluginhost.html#storagehaskey">storageHasKey</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/open-olive/loop-development-kit-node/blob/fa2b79d/src/pluginHost.ts#L17">pluginHost.ts:17</a></li>
+									<li>Defined in <a href="https://github.com/open-olive/loop-development-kit-node/blob/843e171/src/pluginHost.ts#L17">pluginHost.ts:17</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -223,7 +223,7 @@
 							<aside class="tsd-sources">
 								<p>Inherited from <a href="pluginhost.html">PluginHost</a>.<a href="pluginhost.html#storagekeys">storageKeys</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/open-olive/loop-development-kit-node/blob/fa2b79d/src/pluginHost.ts#L22">pluginHost.ts:22</a></li>
+									<li>Defined in <a href="https://github.com/open-olive/loop-development-kit-node/blob/843e171/src/pluginHost.ts#L22">pluginHost.ts:22</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -244,7 +244,7 @@
 							<aside class="tsd-sources">
 								<p>Inherited from <a href="pluginhost.html">PluginHost</a>.<a href="pluginhost.html#storageread">storageRead</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/open-olive/loop-development-kit-node/blob/fa2b79d/src/pluginHost.ts#L30">pluginHost.ts:30</a></li>
+									<li>Defined in <a href="https://github.com/open-olive/loop-development-kit-node/blob/843e171/src/pluginHost.ts#L30">pluginHost.ts:30</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -277,7 +277,7 @@
 							<aside class="tsd-sources">
 								<p>Inherited from <a href="pluginhost.html">PluginHost</a>.<a href="pluginhost.html#storagereadall">storageReadAll</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/open-olive/loop-development-kit-node/blob/fa2b79d/src/pluginHost.ts#L37">pluginHost.ts:37</a></li>
+									<li>Defined in <a href="https://github.com/open-olive/loop-development-kit-node/blob/843e171/src/pluginHost.ts#L37">pluginHost.ts:37</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -301,7 +301,7 @@
 							<aside class="tsd-sources">
 								<p>Inherited from <a href="pluginhost.html">PluginHost</a>.<a href="pluginhost.html#storagewrite">storageWrite</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/open-olive/loop-development-kit-node/blob/fa2b79d/src/pluginHost.ts#L46">pluginHost.ts:46</a></li>
+									<li>Defined in <a href="https://github.com/open-olive/loop-development-kit-node/blob/843e171/src/pluginHost.ts#L46">pluginHost.ts:46</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">

--- a/docs/interfaces/whisper.html
+++ b/docs/interfaces/whisper.html
@@ -114,7 +114,7 @@
 					<div class="tsd-signature tsd-kind-icon">icon<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">string</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/open-olive/loop-development-kit-node/blob/52d7210/src/whisper.ts#L27">whisper.ts:27</a></li>
+							<li>Defined in <a href="https://github.com/open-olive/loop-development-kit-node/blob/fa2b79d/src/whisper.ts#L27">whisper.ts:27</a></li>
 						</ul>
 					</aside>
 					<div class="tsd-comment tsd-typography">
@@ -129,7 +129,7 @@
 					<div class="tsd-signature tsd-kind-icon">label<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">string</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/open-olive/loop-development-kit-node/blob/52d7210/src/whisper.ts#L31">whisper.ts:31</a></li>
+							<li>Defined in <a href="https://github.com/open-olive/loop-development-kit-node/blob/fa2b79d/src/whisper.ts#L31">whisper.ts:31</a></li>
 						</ul>
 					</aside>
 					<div class="tsd-comment tsd-typography">
@@ -144,7 +144,7 @@
 					<div class="tsd-signature tsd-kind-icon">markdown<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">string</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/open-olive/loop-development-kit-node/blob/52d7210/src/whisper.ts#L23">whisper.ts:23</a></li>
+							<li>Defined in <a href="https://github.com/open-olive/loop-development-kit-node/blob/fa2b79d/src/whisper.ts#L23">whisper.ts:23</a></li>
 						</ul>
 					</aside>
 					<div class="tsd-comment tsd-typography">
@@ -159,7 +159,7 @@
 					<div class="tsd-signature tsd-kind-icon">style<span class="tsd-signature-symbol">:</span> <a href="whisperstyle.html" class="tsd-signature-type">WhisperStyle</a></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/open-olive/loop-development-kit-node/blob/52d7210/src/whisper.ts#L35">whisper.ts:35</a></li>
+							<li>Defined in <a href="https://github.com/open-olive/loop-development-kit-node/blob/fa2b79d/src/whisper.ts#L35">whisper.ts:35</a></li>
 						</ul>
 					</aside>
 					<div class="tsd-comment tsd-typography">

--- a/docs/interfaces/whisper.html
+++ b/docs/interfaces/whisper.html
@@ -114,7 +114,7 @@
 					<div class="tsd-signature tsd-kind-icon">icon<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">string</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/open-olive/loop-development-kit-node/blob/4a08e2f/src/whisper.ts#L27">whisper.ts:27</a></li>
+							<li>Defined in <a href="https://github.com/open-olive/loop-development-kit-node/blob/2576fcd/src/whisper.ts#L27">whisper.ts:27</a></li>
 						</ul>
 					</aside>
 					<div class="tsd-comment tsd-typography">
@@ -129,7 +129,7 @@
 					<div class="tsd-signature tsd-kind-icon">label<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">string</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/open-olive/loop-development-kit-node/blob/4a08e2f/src/whisper.ts#L31">whisper.ts:31</a></li>
+							<li>Defined in <a href="https://github.com/open-olive/loop-development-kit-node/blob/2576fcd/src/whisper.ts#L31">whisper.ts:31</a></li>
 						</ul>
 					</aside>
 					<div class="tsd-comment tsd-typography">
@@ -144,7 +144,7 @@
 					<div class="tsd-signature tsd-kind-icon">markdown<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">string</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/open-olive/loop-development-kit-node/blob/4a08e2f/src/whisper.ts#L23">whisper.ts:23</a></li>
+							<li>Defined in <a href="https://github.com/open-olive/loop-development-kit-node/blob/2576fcd/src/whisper.ts#L23">whisper.ts:23</a></li>
 						</ul>
 					</aside>
 					<div class="tsd-comment tsd-typography">
@@ -159,7 +159,7 @@
 					<div class="tsd-signature tsd-kind-icon">style<span class="tsd-signature-symbol">:</span> <a href="whisperstyle.html" class="tsd-signature-type">WhisperStyle</a></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/open-olive/loop-development-kit-node/blob/4a08e2f/src/whisper.ts#L35">whisper.ts:35</a></li>
+							<li>Defined in <a href="https://github.com/open-olive/loop-development-kit-node/blob/2576fcd/src/whisper.ts#L35">whisper.ts:35</a></li>
 						</ul>
 					</aside>
 					<div class="tsd-comment tsd-typography">

--- a/docs/interfaces/whisper.html
+++ b/docs/interfaces/whisper.html
@@ -114,7 +114,7 @@
 					<div class="tsd-signature tsd-kind-icon">icon<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">string</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/open-olive/loop-development-kit-node/blob/843e171/src/whisper.ts#L27">whisper.ts:27</a></li>
+							<li>Defined in <a href="https://github.com/open-olive/loop-development-kit-node/blob/4a08e2f/src/whisper.ts#L27">whisper.ts:27</a></li>
 						</ul>
 					</aside>
 					<div class="tsd-comment tsd-typography">
@@ -129,7 +129,7 @@
 					<div class="tsd-signature tsd-kind-icon">label<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">string</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/open-olive/loop-development-kit-node/blob/843e171/src/whisper.ts#L31">whisper.ts:31</a></li>
+							<li>Defined in <a href="https://github.com/open-olive/loop-development-kit-node/blob/4a08e2f/src/whisper.ts#L31">whisper.ts:31</a></li>
 						</ul>
 					</aside>
 					<div class="tsd-comment tsd-typography">
@@ -144,7 +144,7 @@
 					<div class="tsd-signature tsd-kind-icon">markdown<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">string</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/open-olive/loop-development-kit-node/blob/843e171/src/whisper.ts#L23">whisper.ts:23</a></li>
+							<li>Defined in <a href="https://github.com/open-olive/loop-development-kit-node/blob/4a08e2f/src/whisper.ts#L23">whisper.ts:23</a></li>
 						</ul>
 					</aside>
 					<div class="tsd-comment tsd-typography">
@@ -159,7 +159,7 @@
 					<div class="tsd-signature tsd-kind-icon">style<span class="tsd-signature-symbol">:</span> <a href="whisperstyle.html" class="tsd-signature-type">WhisperStyle</a></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/open-olive/loop-development-kit-node/blob/843e171/src/whisper.ts#L35">whisper.ts:35</a></li>
+							<li>Defined in <a href="https://github.com/open-olive/loop-development-kit-node/blob/4a08e2f/src/whisper.ts#L35">whisper.ts:35</a></li>
 						</ul>
 					</aside>
 					<div class="tsd-comment tsd-typography">

--- a/docs/interfaces/whisper.html
+++ b/docs/interfaces/whisper.html
@@ -114,7 +114,7 @@
 					<div class="tsd-signature tsd-kind-icon">icon<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">string</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/open-olive/loop-development-kit-node/blob/fa2b79d/src/whisper.ts#L27">whisper.ts:27</a></li>
+							<li>Defined in <a href="https://github.com/open-olive/loop-development-kit-node/blob/843e171/src/whisper.ts#L27">whisper.ts:27</a></li>
 						</ul>
 					</aside>
 					<div class="tsd-comment tsd-typography">
@@ -129,7 +129,7 @@
 					<div class="tsd-signature tsd-kind-icon">label<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">string</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/open-olive/loop-development-kit-node/blob/fa2b79d/src/whisper.ts#L31">whisper.ts:31</a></li>
+							<li>Defined in <a href="https://github.com/open-olive/loop-development-kit-node/blob/843e171/src/whisper.ts#L31">whisper.ts:31</a></li>
 						</ul>
 					</aside>
 					<div class="tsd-comment tsd-typography">
@@ -144,7 +144,7 @@
 					<div class="tsd-signature tsd-kind-icon">markdown<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">string</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/open-olive/loop-development-kit-node/blob/fa2b79d/src/whisper.ts#L23">whisper.ts:23</a></li>
+							<li>Defined in <a href="https://github.com/open-olive/loop-development-kit-node/blob/843e171/src/whisper.ts#L23">whisper.ts:23</a></li>
 						</ul>
 					</aside>
 					<div class="tsd-comment tsd-typography">
@@ -159,7 +159,7 @@
 					<div class="tsd-signature tsd-kind-icon">style<span class="tsd-signature-symbol">:</span> <a href="whisperstyle.html" class="tsd-signature-type">WhisperStyle</a></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/open-olive/loop-development-kit-node/blob/fa2b79d/src/whisper.ts#L35">whisper.ts:35</a></li>
+							<li>Defined in <a href="https://github.com/open-olive/loop-development-kit-node/blob/843e171/src/whisper.ts#L35">whisper.ts:35</a></li>
 						</ul>
 					</aside>
 					<div class="tsd-comment tsd-typography">

--- a/docs/interfaces/whisperstyle.html
+++ b/docs/interfaces/whisperstyle.html
@@ -120,7 +120,7 @@
 					<div class="tsd-signature tsd-kind-icon">background<wbr>Color<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">string</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/open-olive/loop-development-kit-node/blob/fa2b79d/src/whisperStyle.ts#L17">whisperStyle.ts:17</a></li>
+							<li>Defined in <a href="https://github.com/open-olive/loop-development-kit-node/blob/843e171/src/whisperStyle.ts#L17">whisperStyle.ts:17</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -130,7 +130,7 @@
 					<div class="tsd-signature tsd-kind-icon">highlight<wbr>Color<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">string</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/open-olive/loop-development-kit-node/blob/fa2b79d/src/whisperStyle.ts#L18">whisperStyle.ts:18</a></li>
+							<li>Defined in <a href="https://github.com/open-olive/loop-development-kit-node/blob/843e171/src/whisperStyle.ts#L18">whisperStyle.ts:18</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -140,7 +140,7 @@
 					<div class="tsd-signature tsd-kind-icon">primary<wbr>Color<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">string</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/open-olive/loop-development-kit-node/blob/fa2b79d/src/whisperStyle.ts#L19">whisperStyle.ts:19</a></li>
+							<li>Defined in <a href="https://github.com/open-olive/loop-development-kit-node/blob/843e171/src/whisperStyle.ts#L19">whisperStyle.ts:19</a></li>
 						</ul>
 					</aside>
 				</section>

--- a/docs/interfaces/whisperstyle.html
+++ b/docs/interfaces/whisperstyle.html
@@ -120,7 +120,7 @@
 					<div class="tsd-signature tsd-kind-icon">background<wbr>Color<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">string</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/open-olive/loop-development-kit-node/blob/843e171/src/whisperStyle.ts#L17">whisperStyle.ts:17</a></li>
+							<li>Defined in <a href="https://github.com/open-olive/loop-development-kit-node/blob/4a08e2f/src/whisperStyle.ts#L17">whisperStyle.ts:17</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -130,7 +130,7 @@
 					<div class="tsd-signature tsd-kind-icon">highlight<wbr>Color<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">string</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/open-olive/loop-development-kit-node/blob/843e171/src/whisperStyle.ts#L18">whisperStyle.ts:18</a></li>
+							<li>Defined in <a href="https://github.com/open-olive/loop-development-kit-node/blob/4a08e2f/src/whisperStyle.ts#L18">whisperStyle.ts:18</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -140,7 +140,7 @@
 					<div class="tsd-signature tsd-kind-icon">primary<wbr>Color<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">string</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/open-olive/loop-development-kit-node/blob/843e171/src/whisperStyle.ts#L19">whisperStyle.ts:19</a></li>
+							<li>Defined in <a href="https://github.com/open-olive/loop-development-kit-node/blob/4a08e2f/src/whisperStyle.ts#L19">whisperStyle.ts:19</a></li>
 						</ul>
 					</aside>
 				</section>

--- a/docs/interfaces/whisperstyle.html
+++ b/docs/interfaces/whisperstyle.html
@@ -120,7 +120,7 @@
 					<div class="tsd-signature tsd-kind-icon">background<wbr>Color<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">string</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/open-olive/loop-development-kit-node/blob/4a08e2f/src/whisperStyle.ts#L17">whisperStyle.ts:17</a></li>
+							<li>Defined in <a href="https://github.com/open-olive/loop-development-kit-node/blob/2576fcd/src/whisperStyle.ts#L17">whisperStyle.ts:17</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -130,7 +130,7 @@
 					<div class="tsd-signature tsd-kind-icon">highlight<wbr>Color<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">string</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/open-olive/loop-development-kit-node/blob/4a08e2f/src/whisperStyle.ts#L18">whisperStyle.ts:18</a></li>
+							<li>Defined in <a href="https://github.com/open-olive/loop-development-kit-node/blob/2576fcd/src/whisperStyle.ts#L18">whisperStyle.ts:18</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -140,7 +140,7 @@
 					<div class="tsd-signature tsd-kind-icon">primary<wbr>Color<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">string</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/open-olive/loop-development-kit-node/blob/4a08e2f/src/whisperStyle.ts#L19">whisperStyle.ts:19</a></li>
+							<li>Defined in <a href="https://github.com/open-olive/loop-development-kit-node/blob/2576fcd/src/whisperStyle.ts#L19">whisperStyle.ts:19</a></li>
 						</ul>
 					</aside>
 				</section>

--- a/docs/interfaces/whisperstyle.html
+++ b/docs/interfaces/whisperstyle.html
@@ -120,7 +120,7 @@
 					<div class="tsd-signature tsd-kind-icon">background<wbr>Color<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">string</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/open-olive/loop-development-kit-node/blob/52d7210/src/whisperStyle.ts#L17">whisperStyle.ts:17</a></li>
+							<li>Defined in <a href="https://github.com/open-olive/loop-development-kit-node/blob/fa2b79d/src/whisperStyle.ts#L17">whisperStyle.ts:17</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -130,7 +130,7 @@
 					<div class="tsd-signature tsd-kind-icon">highlight<wbr>Color<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">string</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/open-olive/loop-development-kit-node/blob/52d7210/src/whisperStyle.ts#L18">whisperStyle.ts:18</a></li>
+							<li>Defined in <a href="https://github.com/open-olive/loop-development-kit-node/blob/fa2b79d/src/whisperStyle.ts#L18">whisperStyle.ts:18</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -140,7 +140,7 @@
 					<div class="tsd-signature tsd-kind-icon">primary<wbr>Color<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">string</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/open-olive/loop-development-kit-node/blob/52d7210/src/whisperStyle.ts#L19">whisperStyle.ts:19</a></li>
+							<li>Defined in <a href="https://github.com/open-olive/loop-development-kit-node/blob/fa2b79d/src/whisperStyle.ts#L19">whisperStyle.ts:19</a></li>
 						</ul>
 					</aside>
 				</section>

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "copyright": "Copyright 2020 Olive",
   "repository": {
     "type": "git",
-    "url": "git@github.com:open-olive/loop-development-kit-node.git"
+    "url": "https://github.com/open-olive/loop-development-kit-node.git"
   },
   "license": "MIT",
   "keywords": [

--- a/readme.md
+++ b/readme.md
@@ -11,7 +11,7 @@ Sidekick expects your library to start its Controller or Sensor GRPC server when
 - Create your `package.json` file.
 - Import the LDK.
 - Create your `main` script (usually `index.js` or `src/index.js`):
-    - Create an implementation object that satisfies the `Controller` or `Sensor` contracts/interfaces.
+    - Create an implementation object that satisfies the [[Controller]] or [[Sensor]] contracts/interfaces.
     - Initialize the appropriate plugin with your implementation and call `.serve` on it.
 
 #### Install the Package

--- a/readme.md
+++ b/readme.md
@@ -11,24 +11,15 @@ Sidekick expects your library to start its Controller or Sensor GRPC server when
 - Create your `package.json` file.
 - Import the LDK.
 - Create your `main` script (usually `index.js` or `src/index.js`):
+    - Create an implementation object that satisfies the `Controller` or `Sensor` contracts/interfaces.
+    - Initialize the appropriate plugin with your implementation and call `.serve` on it.
 
-  - Create an implementation object that satisfies the [[Controller]] or [[Sensor]] contracts/interfaces.
-  - Initialize the appropriate plugin with your implementation and call `.serve` on it.
+#### Install the Package
 
-#### Install the package
-
-Add the dependency to your package.json under the dependencies:
-
-```json
-"dependencies": {
-  "ldk": "git+https://github.com/open-olive/loop-development-kit-node.git"
-}
-```
-
-Install using NPM
+Install this library as a dependency:
 
 ```shell
-npm i
+npm i @oliveai/ldk -P
 ```
 
 ##### Example Controller
@@ -58,17 +49,15 @@ serveSensorPlugin(impl);
 ```
 
 ### Running Locally
- 
+
 #### Local Plugin Command (Recommended)
 
 Sidekick lets you add a local command as Local Plugins:
 
 1. Open Sidekick.
 2. Open the Loop Library:
-
-- Click the Hamburger icon.
-- Click Loop Library.
-
+    1. Click the Hamburger icon.
+    2. Click Loop Library.
 3. Click the Install Local Plugin button:
 4. Select whether it's a Controller or Sensor.
 5. Select the working directory for the command.
@@ -87,11 +76,11 @@ Sidekick logs are available in the following directories for your OS:
 
 ```shell
 ~/Library/Logs/Sidekick # MacOS
-/var/log/Sidekick # Linux
-%AppData%/Logs # Windows
+/var/log/Sidekick       # Linux
+%AppData%/Logs          # Windows
 ```
 
-`tail` the log file (usually `Sidekick-X.Y.Z.log`) to watch things happen!
+`tail -f` the log file (usually `Sidekick-X.Y.Z.log`) to watch things happen!
 
 ## Deploying
 
@@ -105,7 +94,7 @@ Sidekick expects the following files when running a plugin:
 
 We've made the following commands available to you:
 
-```
+```shell
 ldk build # Builds your project. Expects that you have index.js as your entry point, plugin.json, storage.json files.
 ldk deploy # Deploys your project to the Application Support/Sidekick/plugins/controllers/YOUR_PACKAGE_NAME folder
 ```
@@ -134,7 +123,7 @@ Each command takes options. Run `ldk help <command>` for details.
 
 #### `storage.json`
 
-Each storage key you access must be specified in the `storage.json` file. 
+Each storage key you access must be specified in the `storage.json` file.
 
 ```json
 {


### PR DESCRIPTION
After merging the previous PR, the `NPM Publish` Action was triggered correctly (when I published a release), but failed at the `npm publish` step. Going through the logs, everything seems to be set correctly (the auth secret, all the variables and environment variables).
But looking through the code for `actions/setup-node@v1` action and trying to understand how it and the `npm` commands work, I think I understand why it was failing. The `actions/setup-node@v1` action sets up its own `.npmrc` file with specific `registry`/auth configuration (for publishing) in a temp dir and sets an env var to tell `npm` commands to use that file.
The way `npm` looks for `.npmrc` files ([current directory, up the current directory tree, different environment variables, global path](https://docs.npmjs.com/misc/config#npmrc-files)), I'm pretty sure the `.npmrc` file in our repo is taking precedence over the custom one (set by an env var). It's possible that simply removing the `registry` setting would fix this issue, but it's just easier to not have an `.npmrc` file to see if that resolves the issue. Our current `.npmrc` doesn't really have anything important in it anyways.

- Removed `.npmrc` file.
- Added `.npmignore` - this is so unnecessary files **aren't** included when the repo is published to NPM.
- Updated `package.json` Repository value.
- Cleaned up `.gitignore` and `README`.