### PR TITLE
SIDE-533 Publish LDK to NPM (Part 3)

### DIFF
--- a/.github/workflows/npm.yml
+++ b/.github/workflows/npm.yml
@@ -18,14 +18,13 @@ jobs:
       - uses: actions/checkout@v2
       - uses: actions/setup-node@v1
         with:
-          check-latest: 'true'
           node-version: '12.x'
-          registry-url: 'https://registry.npmjs.org/'
       - run: npm set audit false
       - run: npm ci
       - run: npm run build --if-present
+      - run: printf '\n//registry.npmjs.org/:_authToken=${NPM_TOKEN}' >> .npmrc
       - run: npm publish --access public
         env:
           # `secrets.NPM_TOKEN` references a GitHub Secret configured for this repo or organization,
           # and is used to authenticate for the NPM publish command.
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,2 @@
+registry = https://registry.npmjs.org/
+save-exact = true

--- a/docs/classes/controllerplugin.html
+++ b/docs/classes/controllerplugin.html
@@ -111,7 +111,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/open-olive/loop-development-kit-node/blob/aa9a4eb/src/controllerPlugin.ts#L16">controllerPlugin.ts:16</a></li>
+									<li>Defined in <a href="https://github.com/open-olive/loop-development-kit-node/blob/cd20781/src/controllerPlugin.ts#L16">controllerPlugin.ts:16</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -148,7 +148,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/open-olive/loop-development-kit-node/blob/aa9a4eb/src/controllerPlugin.ts#L41">controllerPlugin.ts:41</a></li>
+									<li>Defined in <a href="https://github.com/open-olive/loop-development-kit-node/blob/cd20781/src/controllerPlugin.ts#L41">controllerPlugin.ts:41</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">

--- a/docs/classes/logger.html
+++ b/docs/classes/logger.html
@@ -116,7 +116,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/open-olive/loop-development-kit-node/blob/aa9a4eb/src/logging.ts#L25">logging.ts:25</a></li>
+									<li>Defined in <a href="https://github.com/open-olive/loop-development-kit-node/blob/cd20781/src/logging.ts#L25">logging.ts:25</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -167,7 +167,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/open-olive/loop-development-kit-node/blob/aa9a4eb/src/logging.ts#L112">logging.ts:112</a></li>
+									<li>Defined in <a href="https://github.com/open-olive/loop-development-kit-node/blob/cd20781/src/logging.ts#L112">logging.ts:112</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -215,7 +215,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/open-olive/loop-development-kit-node/blob/aa9a4eb/src/logging.ts#L175">logging.ts:175</a></li>
+									<li>Defined in <a href="https://github.com/open-olive/loop-development-kit-node/blob/cd20781/src/logging.ts#L175">logging.ts:175</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -263,7 +263,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/open-olive/loop-development-kit-node/blob/aa9a4eb/src/logging.ts#L133">logging.ts:133</a></li>
+									<li>Defined in <a href="https://github.com/open-olive/loop-development-kit-node/blob/cd20781/src/logging.ts#L133">logging.ts:133</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -311,7 +311,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/open-olive/loop-development-kit-node/blob/aa9a4eb/src/logging.ts#L91">logging.ts:91</a></li>
+									<li>Defined in <a href="https://github.com/open-olive/loop-development-kit-node/blob/cd20781/src/logging.ts#L91">logging.ts:91</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -359,7 +359,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/open-olive/loop-development-kit-node/blob/aa9a4eb/src/logging.ts#L154">logging.ts:154</a></li>
+									<li>Defined in <a href="https://github.com/open-olive/loop-development-kit-node/blob/cd20781/src/logging.ts#L154">logging.ts:154</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -407,7 +407,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/open-olive/loop-development-kit-node/blob/aa9a4eb/src/logging.ts#L69">logging.ts:69</a></li>
+									<li>Defined in <a href="https://github.com/open-olive/loop-development-kit-node/blob/cd20781/src/logging.ts#L69">logging.ts:69</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">

--- a/docs/classes/sensorplugin.html
+++ b/docs/classes/sensorplugin.html
@@ -111,7 +111,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/open-olive/loop-development-kit-node/blob/aa9a4eb/src/sensorPlugin.ts#L17">sensorPlugin.ts:17</a></li>
+									<li>Defined in <a href="https://github.com/open-olive/loop-development-kit-node/blob/cd20781/src/sensorPlugin.ts#L17">sensorPlugin.ts:17</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -148,7 +148,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/open-olive/loop-development-kit-node/blob/aa9a4eb/src/sensorPlugin.ts#L41">sensorPlugin.ts:41</a></li>
+									<li>Defined in <a href="https://github.com/open-olive/loop-development-kit-node/blob/cd20781/src/sensorPlugin.ts#L41">sensorPlugin.ts:41</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">

--- a/docs/enums/access.html
+++ b/docs/enums/access.html
@@ -89,7 +89,7 @@
 					<div class="tsd-signature tsd-kind-icon">ORGANIZATION<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-symbol"> = &quot;organization&quot;</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/open-olive/loop-development-kit-node/blob/aa9a4eb/src/access.ts#L3">access.ts:3</a></li>
+							<li>Defined in <a href="https://github.com/open-olive/loop-development-kit-node/blob/cd20781/src/access.ts#L3">access.ts:3</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -99,7 +99,7 @@
 					<div class="tsd-signature tsd-kind-icon">PUBLIC<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-symbol"> = &quot;public&quot;</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/open-olive/loop-development-kit-node/blob/aa9a4eb/src/access.ts#L4">access.ts:4</a></li>
+							<li>Defined in <a href="https://github.com/open-olive/loop-development-kit-node/blob/cd20781/src/access.ts#L4">access.ts:4</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -109,7 +109,7 @@
 					<div class="tsd-signature tsd-kind-icon">UNKNOWN<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-symbol"> = &quot;unknown&quot;</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/open-olive/loop-development-kit-node/blob/aa9a4eb/src/access.ts#L5">access.ts:5</a></li>
+							<li>Defined in <a href="https://github.com/open-olive/loop-development-kit-node/blob/cd20781/src/access.ts#L5">access.ts:5</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -119,7 +119,7 @@
 					<div class="tsd-signature tsd-kind-icon">USER<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-symbol"> = &quot;user&quot;</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/open-olive/loop-development-kit-node/blob/aa9a4eb/src/access.ts#L6">access.ts:6</a></li>
+							<li>Defined in <a href="https://github.com/open-olive/loop-development-kit-node/blob/cd20781/src/access.ts#L6">access.ts:6</a></li>
 						</ul>
 					</aside>
 				</section>

--- a/docs/enums/category.html
+++ b/docs/enums/category.html
@@ -90,7 +90,7 @@
 					<div class="tsd-signature tsd-kind-icon">CONTROLLER<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-symbol"> = &quot;Controller&quot;</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/open-olive/loop-development-kit-node/blob/aa9a4eb/src/categories.ts#L3">categories.ts:3</a></li>
+							<li>Defined in <a href="https://github.com/open-olive/loop-development-kit-node/blob/cd20781/src/categories.ts#L3">categories.ts:3</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -100,7 +100,7 @@
 					<div class="tsd-signature tsd-kind-icon">INTELLIGENCE<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-symbol"> = &quot;Intelligence&quot;</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/open-olive/loop-development-kit-node/blob/aa9a4eb/src/categories.ts#L4">categories.ts:4</a></li>
+							<li>Defined in <a href="https://github.com/open-olive/loop-development-kit-node/blob/cd20781/src/categories.ts#L4">categories.ts:4</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -110,7 +110,7 @@
 					<div class="tsd-signature tsd-kind-icon">SENSOR<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-symbol"> = &quot;Sensor&quot;</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/open-olive/loop-development-kit-node/blob/aa9a4eb/src/categories.ts#L5">categories.ts:5</a></li>
+							<li>Defined in <a href="https://github.com/open-olive/loop-development-kit-node/blob/cd20781/src/categories.ts#L5">categories.ts:5</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -120,7 +120,7 @@
 					<div class="tsd-signature tsd-kind-icon">SIDEKICK<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-symbol"> = &quot;Sidekick&quot;</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/open-olive/loop-development-kit-node/blob/aa9a4eb/src/categories.ts#L6">categories.ts:6</a></li>
+							<li>Defined in <a href="https://github.com/open-olive/loop-development-kit-node/blob/cd20781/src/categories.ts#L6">categories.ts:6</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -130,7 +130,7 @@
 					<div class="tsd-signature tsd-kind-icon">UNKNOWN<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-symbol"> = &quot;Unknown&quot;</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/open-olive/loop-development-kit-node/blob/aa9a4eb/src/categories.ts#L7">categories.ts:7</a></li>
+							<li>Defined in <a href="https://github.com/open-olive/loop-development-kit-node/blob/cd20781/src/categories.ts#L7">categories.ts:7</a></li>
 						</ul>
 					</aside>
 				</section>

--- a/docs/enums/operatingsystem.html
+++ b/docs/enums/operatingsystem.html
@@ -90,7 +90,7 @@
 					<div class="tsd-signature tsd-kind-icon">ANY<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-symbol"> = &quot;any&quot;</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/open-olive/loop-development-kit-node/blob/aa9a4eb/src/operatingSystem.ts#L3">operatingSystem.ts:3</a></li>
+							<li>Defined in <a href="https://github.com/open-olive/loop-development-kit-node/blob/cd20781/src/operatingSystem.ts#L3">operatingSystem.ts:3</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -100,7 +100,7 @@
 					<div class="tsd-signature tsd-kind-icon">LINUX<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-symbol"> = &quot;linux&quot;</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/open-olive/loop-development-kit-node/blob/aa9a4eb/src/operatingSystem.ts#L4">operatingSystem.ts:4</a></li>
+							<li>Defined in <a href="https://github.com/open-olive/loop-development-kit-node/blob/cd20781/src/operatingSystem.ts#L4">operatingSystem.ts:4</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -110,7 +110,7 @@
 					<div class="tsd-signature tsd-kind-icon">MACOS<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-symbol"> = &quot;darwin&quot;</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/open-olive/loop-development-kit-node/blob/aa9a4eb/src/operatingSystem.ts#L5">operatingSystem.ts:5</a></li>
+							<li>Defined in <a href="https://github.com/open-olive/loop-development-kit-node/blob/cd20781/src/operatingSystem.ts#L5">operatingSystem.ts:5</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -120,7 +120,7 @@
 					<div class="tsd-signature tsd-kind-icon">UNKNOWN<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-symbol"> = &quot;unknown&quot;</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/open-olive/loop-development-kit-node/blob/aa9a4eb/src/operatingSystem.ts#L6">operatingSystem.ts:6</a></li>
+							<li>Defined in <a href="https://github.com/open-olive/loop-development-kit-node/blob/cd20781/src/operatingSystem.ts#L6">operatingSystem.ts:6</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -130,7 +130,7 @@
 					<div class="tsd-signature tsd-kind-icon">WINDOWS<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-symbol"> = &quot;win32&quot;</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/open-olive/loop-development-kit-node/blob/aa9a4eb/src/operatingSystem.ts#L7">operatingSystem.ts:7</a></li>
+							<li>Defined in <a href="https://github.com/open-olive/loop-development-kit-node/blob/cd20781/src/operatingSystem.ts#L7">operatingSystem.ts:7</a></li>
 						</ul>
 					</aside>
 				</section>

--- a/docs/globals.html
+++ b/docs/globals.html
@@ -129,7 +129,7 @@
 					<div class="tsd-signature tsd-kind-icon">Request&lt;TRequestType, TResponseType&gt;<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-symbol">(</span>request<span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">TRequestType</span>, callback<span class="tsd-signature-symbol">: </span><span class="tsd-signature-symbol">(</span>error<span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">grpc.ServiceError</span><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">null</span>, response<span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">TResponseType</span><span class="tsd-signature-symbol">)</span><span class="tsd-signature-symbol"> =&gt; </span><span class="tsd-signature-type">void</span><span class="tsd-signature-symbol">)</span><span class="tsd-signature-symbol"> =&gt; </span><span class="tsd-signature-type">void</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/open-olive/loop-development-kit-node/blob/aa9a4eb/src/commonHostServer.ts#L5">commonHostServer.ts:5</a></li>
+							<li>Defined in <a href="https://github.com/open-olive/loop-development-kit-node/blob/cd20781/src/commonHostServer.ts#L5">commonHostServer.ts:5</a></li>
 						</ul>
 					</aside>
 					<h4 class="tsd-type-parameters-title">Type parameters</h4>
@@ -196,7 +196,7 @@
 					<div class="tsd-signature tsd-kind-icon">categories<span class="tsd-signature-symbol">:</span> <a href="enums/category.html" class="tsd-signature-type">Category</a><span class="tsd-signature-symbol">[]</span><span class="tsd-signature-symbol"> = [Category.UNKNOWN,Category.INTELLIGENCE,Category.CONTROLLER,Category.SENSOR,Category.SIDEKICK,]</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/open-olive/loop-development-kit-node/blob/aa9a4eb/src/categories.ts#L10">categories.ts:10</a></li>
+							<li>Defined in <a href="https://github.com/open-olive/loop-development-kit-node/blob/cd20781/src/categories.ts#L10">categories.ts:10</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -206,7 +206,7 @@
 					<div class="tsd-signature tsd-kind-icon">err<wbr>Missing<wbr>Required<wbr>Key<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">Error</span><span class="tsd-signature-symbol"> = new Error(&#x27;key is required&#x27;)</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/open-olive/loop-development-kit-node/blob/aa9a4eb/src/grpcHostClient.ts#L6">grpcHostClient.ts:6</a></li>
+							<li>Defined in <a href="https://github.com/open-olive/loop-development-kit-node/blob/cd20781/src/grpcHostClient.ts#L6">grpcHostClient.ts:6</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -216,7 +216,7 @@
 					<div class="tsd-signature tsd-kind-icon">err<wbr>Missing<wbr>Required<wbr>Value<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">Error</span><span class="tsd-signature-symbol"> = new Error(&#x27;value is required&#x27;)</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/open-olive/loop-development-kit-node/blob/aa9a4eb/src/grpcHostClient.ts#L7">grpcHostClient.ts:7</a></li>
+							<li>Defined in <a href="https://github.com/open-olive/loop-development-kit-node/blob/cd20781/src/grpcHostClient.ts#L7">grpcHostClient.ts:7</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -226,7 +226,7 @@
 					<div class="tsd-signature tsd-kind-icon">pid<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">number</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/open-olive/loop-development-kit-node/blob/aa9a4eb/src/logging.ts#L6">logging.ts:6</a></li>
+							<li>Defined in <a href="https://github.com/open-olive/loop-development-kit-node/blob/cd20781/src/logging.ts#L6">logging.ts:6</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -236,7 +236,7 @@
 					<div class="tsd-signature tsd-kind-icon">program<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">Command</span><span class="tsd-signature-symbol"> = new Command()</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/open-olive/loop-development-kit-node/blob/aa9a4eb/src/commands.ts#L4">commands.ts:4</a></li>
+							<li>Defined in <a href="https://github.com/open-olive/loop-development-kit-node/blob/cd20781/src/commands.ts#L4">commands.ts:4</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -253,7 +253,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/open-olive/loop-development-kit-node/blob/aa9a4eb/src/serve.ts#L11">serve.ts:11</a></li>
+									<li>Defined in <a href="https://github.com/open-olive/loop-development-kit-node/blob/cd20781/src/serve.ts#L11">serve.ts:11</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -284,7 +284,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/open-olive/loop-development-kit-node/blob/aa9a4eb/src/serve.ts#L21">serve.ts:21</a></li>
+									<li>Defined in <a href="https://github.com/open-olive/loop-development-kit-node/blob/cd20781/src/serve.ts#L21">serve.ts:21</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">

--- a/docs/interfaces/controller.html
+++ b/docs/interfaces/controller.html
@@ -141,7 +141,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/open-olive/loop-development-kit-node/blob/aa9a4eb/src/controller.ts#L63">controller.ts:63</a></li>
+									<li>Defined in <a href="https://github.com/open-olive/loop-development-kit-node/blob/cd20781/src/controller.ts#L63">controller.ts:63</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -171,7 +171,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/open-olive/loop-development-kit-node/blob/aa9a4eb/src/controller.ts#L51">controller.ts:51</a></li>
+									<li>Defined in <a href="https://github.com/open-olive/loop-development-kit-node/blob/cd20781/src/controller.ts#L51">controller.ts:51</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -203,7 +203,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/open-olive/loop-development-kit-node/blob/aa9a4eb/src/controller.ts#L56">controller.ts:56</a></li>
+									<li>Defined in <a href="https://github.com/open-olive/loop-development-kit-node/blob/cd20781/src/controller.ts#L56">controller.ts:56</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">

--- a/docs/interfaces/controllerhost.html
+++ b/docs/interfaces/controllerhost.html
@@ -111,7 +111,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/open-olive/loop-development-kit-node/blob/aa9a4eb/src/controllerHost.ts#L8">controllerHost.ts:8</a></li>
+									<li>Defined in <a href="https://github.com/open-olive/loop-development-kit-node/blob/cd20781/src/controllerHost.ts#L8">controllerHost.ts:8</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -140,7 +140,7 @@
 							<aside class="tsd-sources">
 								<p>Inherited from <a href="pluginhost.html">PluginHost</a>.<a href="pluginhost.html#storagedelete">storageDelete</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/open-olive/loop-development-kit-node/blob/aa9a4eb/src/pluginHost.ts#L6">pluginHost.ts:6</a></li>
+									<li>Defined in <a href="https://github.com/open-olive/loop-development-kit-node/blob/cd20781/src/pluginHost.ts#L6">pluginHost.ts:6</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -170,7 +170,7 @@
 							<aside class="tsd-sources">
 								<p>Inherited from <a href="pluginhost.html">PluginHost</a>.<a href="pluginhost.html#storagedeleteall">storageDeleteAll</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/open-olive/loop-development-kit-node/blob/aa9a4eb/src/pluginHost.ts#L11">pluginHost.ts:11</a></li>
+									<li>Defined in <a href="https://github.com/open-olive/loop-development-kit-node/blob/cd20781/src/pluginHost.ts#L11">pluginHost.ts:11</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -191,7 +191,7 @@
 							<aside class="tsd-sources">
 								<p>Inherited from <a href="pluginhost.html">PluginHost</a>.<a href="pluginhost.html#storagehaskey">storageHasKey</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/open-olive/loop-development-kit-node/blob/aa9a4eb/src/pluginHost.ts#L17">pluginHost.ts:17</a></li>
+									<li>Defined in <a href="https://github.com/open-olive/loop-development-kit-node/blob/cd20781/src/pluginHost.ts#L17">pluginHost.ts:17</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -221,7 +221,7 @@
 							<aside class="tsd-sources">
 								<p>Inherited from <a href="pluginhost.html">PluginHost</a>.<a href="pluginhost.html#storagekeys">storageKeys</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/open-olive/loop-development-kit-node/blob/aa9a4eb/src/pluginHost.ts#L22">pluginHost.ts:22</a></li>
+									<li>Defined in <a href="https://github.com/open-olive/loop-development-kit-node/blob/cd20781/src/pluginHost.ts#L22">pluginHost.ts:22</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -242,7 +242,7 @@
 							<aside class="tsd-sources">
 								<p>Inherited from <a href="pluginhost.html">PluginHost</a>.<a href="pluginhost.html#storageread">storageRead</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/open-olive/loop-development-kit-node/blob/aa9a4eb/src/pluginHost.ts#L30">pluginHost.ts:30</a></li>
+									<li>Defined in <a href="https://github.com/open-olive/loop-development-kit-node/blob/cd20781/src/pluginHost.ts#L30">pluginHost.ts:30</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -275,7 +275,7 @@
 							<aside class="tsd-sources">
 								<p>Inherited from <a href="pluginhost.html">PluginHost</a>.<a href="pluginhost.html#storagereadall">storageReadAll</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/open-olive/loop-development-kit-node/blob/aa9a4eb/src/pluginHost.ts#L37">pluginHost.ts:37</a></li>
+									<li>Defined in <a href="https://github.com/open-olive/loop-development-kit-node/blob/cd20781/src/pluginHost.ts#L37">pluginHost.ts:37</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -299,7 +299,7 @@
 							<aside class="tsd-sources">
 								<p>Inherited from <a href="pluginhost.html">PluginHost</a>.<a href="pluginhost.html#storagewrite">storageWrite</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/open-olive/loop-development-kit-node/blob/aa9a4eb/src/pluginHost.ts#L46">pluginHost.ts:46</a></li>
+									<li>Defined in <a href="https://github.com/open-olive/loop-development-kit-node/blob/cd20781/src/pluginHost.ts#L46">pluginHost.ts:46</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -337,7 +337,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/open-olive/loop-development-kit-node/blob/aa9a4eb/src/controllerHost.ts#L9">controllerHost.ts:9</a></li>
+									<li>Defined in <a href="https://github.com/open-olive/loop-development-kit-node/blob/cd20781/src/controllerHost.ts#L9">controllerHost.ts:9</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>

--- a/docs/interfaces/pluginevent.html
+++ b/docs/interfaces/pluginevent.html
@@ -101,7 +101,7 @@
 					<div class="tsd-signature tsd-kind-icon">data<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-symbol">{}</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/open-olive/loop-development-kit-node/blob/aa9a4eb/src/pluginEvent.ts#L6">pluginEvent.ts:6</a></li>
+							<li>Defined in <a href="https://github.com/open-olive/loop-development-kit-node/blob/cd20781/src/pluginEvent.ts#L6">pluginEvent.ts:6</a></li>
 						</ul>
 					</aside>
 					<div class="tsd-type-declaration">

--- a/docs/interfaces/pluginhost.html
+++ b/docs/interfaces/pluginhost.html
@@ -112,7 +112,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/open-olive/loop-development-kit-node/blob/aa9a4eb/src/pluginHost.ts#L6">pluginHost.ts:6</a></li>
+									<li>Defined in <a href="https://github.com/open-olive/loop-development-kit-node/blob/cd20781/src/pluginHost.ts#L6">pluginHost.ts:6</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -141,7 +141,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/open-olive/loop-development-kit-node/blob/aa9a4eb/src/pluginHost.ts#L11">pluginHost.ts:11</a></li>
+									<li>Defined in <a href="https://github.com/open-olive/loop-development-kit-node/blob/cd20781/src/pluginHost.ts#L11">pluginHost.ts:11</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -161,7 +161,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/open-olive/loop-development-kit-node/blob/aa9a4eb/src/pluginHost.ts#L17">pluginHost.ts:17</a></li>
+									<li>Defined in <a href="https://github.com/open-olive/loop-development-kit-node/blob/cd20781/src/pluginHost.ts#L17">pluginHost.ts:17</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -190,7 +190,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/open-olive/loop-development-kit-node/blob/aa9a4eb/src/pluginHost.ts#L22">pluginHost.ts:22</a></li>
+									<li>Defined in <a href="https://github.com/open-olive/loop-development-kit-node/blob/cd20781/src/pluginHost.ts#L22">pluginHost.ts:22</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -210,7 +210,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/open-olive/loop-development-kit-node/blob/aa9a4eb/src/pluginHost.ts#L30">pluginHost.ts:30</a></li>
+									<li>Defined in <a href="https://github.com/open-olive/loop-development-kit-node/blob/cd20781/src/pluginHost.ts#L30">pluginHost.ts:30</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -242,7 +242,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/open-olive/loop-development-kit-node/blob/aa9a4eb/src/pluginHost.ts#L37">pluginHost.ts:37</a></li>
+									<li>Defined in <a href="https://github.com/open-olive/loop-development-kit-node/blob/cd20781/src/pluginHost.ts#L37">pluginHost.ts:37</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -265,7 +265,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/open-olive/loop-development-kit-node/blob/aa9a4eb/src/pluginHost.ts#L46">pluginHost.ts:46</a></li>
+									<li>Defined in <a href="https://github.com/open-olive/loop-development-kit-node/blob/cd20781/src/pluginHost.ts#L46">pluginHost.ts:46</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">

--- a/docs/interfaces/sensor.html
+++ b/docs/interfaces/sensor.html
@@ -138,7 +138,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/open-olive/loop-development-kit-node/blob/aa9a4eb/src/sensor.ts#L60">sensor.ts:60</a></li>
+									<li>Defined in <a href="https://github.com/open-olive/loop-development-kit-node/blob/cd20781/src/sensor.ts#L60">sensor.ts:60</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -169,7 +169,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/open-olive/loop-development-kit-node/blob/aa9a4eb/src/sensor.ts#L48">sensor.ts:48</a></li>
+									<li>Defined in <a href="https://github.com/open-olive/loop-development-kit-node/blob/cd20781/src/sensor.ts#L48">sensor.ts:48</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -200,7 +200,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/open-olive/loop-development-kit-node/blob/aa9a4eb/src/sensor.ts#L53">sensor.ts:53</a></li>
+									<li>Defined in <a href="https://github.com/open-olive/loop-development-kit-node/blob/cd20781/src/sensor.ts#L53">sensor.ts:53</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">

--- a/docs/interfaces/sensorhost.html
+++ b/docs/interfaces/sensorhost.html
@@ -110,7 +110,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/open-olive/loop-development-kit-node/blob/aa9a4eb/src/sensorHost.ts#L10">sensorHost.ts:10</a></li>
+									<li>Defined in <a href="https://github.com/open-olive/loop-development-kit-node/blob/cd20781/src/sensorHost.ts#L10">sensorHost.ts:10</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -142,7 +142,7 @@
 							<aside class="tsd-sources">
 								<p>Inherited from <a href="pluginhost.html">PluginHost</a>.<a href="pluginhost.html#storagedelete">storageDelete</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/open-olive/loop-development-kit-node/blob/aa9a4eb/src/pluginHost.ts#L6">pluginHost.ts:6</a></li>
+									<li>Defined in <a href="https://github.com/open-olive/loop-development-kit-node/blob/cd20781/src/pluginHost.ts#L6">pluginHost.ts:6</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -172,7 +172,7 @@
 							<aside class="tsd-sources">
 								<p>Inherited from <a href="pluginhost.html">PluginHost</a>.<a href="pluginhost.html#storagedeleteall">storageDeleteAll</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/open-olive/loop-development-kit-node/blob/aa9a4eb/src/pluginHost.ts#L11">pluginHost.ts:11</a></li>
+									<li>Defined in <a href="https://github.com/open-olive/loop-development-kit-node/blob/cd20781/src/pluginHost.ts#L11">pluginHost.ts:11</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -193,7 +193,7 @@
 							<aside class="tsd-sources">
 								<p>Inherited from <a href="pluginhost.html">PluginHost</a>.<a href="pluginhost.html#storagehaskey">storageHasKey</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/open-olive/loop-development-kit-node/blob/aa9a4eb/src/pluginHost.ts#L17">pluginHost.ts:17</a></li>
+									<li>Defined in <a href="https://github.com/open-olive/loop-development-kit-node/blob/cd20781/src/pluginHost.ts#L17">pluginHost.ts:17</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -223,7 +223,7 @@
 							<aside class="tsd-sources">
 								<p>Inherited from <a href="pluginhost.html">PluginHost</a>.<a href="pluginhost.html#storagekeys">storageKeys</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/open-olive/loop-development-kit-node/blob/aa9a4eb/src/pluginHost.ts#L22">pluginHost.ts:22</a></li>
+									<li>Defined in <a href="https://github.com/open-olive/loop-development-kit-node/blob/cd20781/src/pluginHost.ts#L22">pluginHost.ts:22</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -244,7 +244,7 @@
 							<aside class="tsd-sources">
 								<p>Inherited from <a href="pluginhost.html">PluginHost</a>.<a href="pluginhost.html#storageread">storageRead</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/open-olive/loop-development-kit-node/blob/aa9a4eb/src/pluginHost.ts#L30">pluginHost.ts:30</a></li>
+									<li>Defined in <a href="https://github.com/open-olive/loop-development-kit-node/blob/cd20781/src/pluginHost.ts#L30">pluginHost.ts:30</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -277,7 +277,7 @@
 							<aside class="tsd-sources">
 								<p>Inherited from <a href="pluginhost.html">PluginHost</a>.<a href="pluginhost.html#storagereadall">storageReadAll</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/open-olive/loop-development-kit-node/blob/aa9a4eb/src/pluginHost.ts#L37">pluginHost.ts:37</a></li>
+									<li>Defined in <a href="https://github.com/open-olive/loop-development-kit-node/blob/cd20781/src/pluginHost.ts#L37">pluginHost.ts:37</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -301,7 +301,7 @@
 							<aside class="tsd-sources">
 								<p>Inherited from <a href="pluginhost.html">PluginHost</a>.<a href="pluginhost.html#storagewrite">storageWrite</a></p>
 								<ul>
-									<li>Defined in <a href="https://github.com/open-olive/loop-development-kit-node/blob/aa9a4eb/src/pluginHost.ts#L46">pluginHost.ts:46</a></li>
+									<li>Defined in <a href="https://github.com/open-olive/loop-development-kit-node/blob/cd20781/src/pluginHost.ts#L46">pluginHost.ts:46</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">

--- a/docs/interfaces/whisper.html
+++ b/docs/interfaces/whisper.html
@@ -114,7 +114,7 @@
 					<div class="tsd-signature tsd-kind-icon">icon<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">string</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/open-olive/loop-development-kit-node/blob/aa9a4eb/src/whisper.ts#L27">whisper.ts:27</a></li>
+							<li>Defined in <a href="https://github.com/open-olive/loop-development-kit-node/blob/cd20781/src/whisper.ts#L27">whisper.ts:27</a></li>
 						</ul>
 					</aside>
 					<div class="tsd-comment tsd-typography">
@@ -129,7 +129,7 @@
 					<div class="tsd-signature tsd-kind-icon">label<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">string</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/open-olive/loop-development-kit-node/blob/aa9a4eb/src/whisper.ts#L31">whisper.ts:31</a></li>
+							<li>Defined in <a href="https://github.com/open-olive/loop-development-kit-node/blob/cd20781/src/whisper.ts#L31">whisper.ts:31</a></li>
 						</ul>
 					</aside>
 					<div class="tsd-comment tsd-typography">
@@ -144,7 +144,7 @@
 					<div class="tsd-signature tsd-kind-icon">markdown<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">string</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/open-olive/loop-development-kit-node/blob/aa9a4eb/src/whisper.ts#L23">whisper.ts:23</a></li>
+							<li>Defined in <a href="https://github.com/open-olive/loop-development-kit-node/blob/cd20781/src/whisper.ts#L23">whisper.ts:23</a></li>
 						</ul>
 					</aside>
 					<div class="tsd-comment tsd-typography">
@@ -159,7 +159,7 @@
 					<div class="tsd-signature tsd-kind-icon">style<span class="tsd-signature-symbol">:</span> <a href="whisperstyle.html" class="tsd-signature-type">WhisperStyle</a></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/open-olive/loop-development-kit-node/blob/aa9a4eb/src/whisper.ts#L35">whisper.ts:35</a></li>
+							<li>Defined in <a href="https://github.com/open-olive/loop-development-kit-node/blob/cd20781/src/whisper.ts#L35">whisper.ts:35</a></li>
 						</ul>
 					</aside>
 					<div class="tsd-comment tsd-typography">

--- a/docs/interfaces/whisperstyle.html
+++ b/docs/interfaces/whisperstyle.html
@@ -120,7 +120,7 @@
 					<div class="tsd-signature tsd-kind-icon">background<wbr>Color<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">string</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/open-olive/loop-development-kit-node/blob/aa9a4eb/src/whisperStyle.ts#L17">whisperStyle.ts:17</a></li>
+							<li>Defined in <a href="https://github.com/open-olive/loop-development-kit-node/blob/cd20781/src/whisperStyle.ts#L17">whisperStyle.ts:17</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -130,7 +130,7 @@
 					<div class="tsd-signature tsd-kind-icon">highlight<wbr>Color<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">string</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/open-olive/loop-development-kit-node/blob/aa9a4eb/src/whisperStyle.ts#L18">whisperStyle.ts:18</a></li>
+							<li>Defined in <a href="https://github.com/open-olive/loop-development-kit-node/blob/cd20781/src/whisperStyle.ts#L18">whisperStyle.ts:18</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -140,7 +140,7 @@
 					<div class="tsd-signature tsd-kind-icon">primary<wbr>Color<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">string</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/open-olive/loop-development-kit-node/blob/aa9a4eb/src/whisperStyle.ts#L19">whisperStyle.ts:19</a></li>
+							<li>Defined in <a href="https://github.com/open-olive/loop-development-kit-node/blob/cd20781/src/whisperStyle.ts#L19">whisperStyle.ts:19</a></li>
 						</ul>
 					</aside>
 				</section>


### PR DESCRIPTION
After more investigation, all I can determine is that `actions/setup-node@v1` does not set up NPM auth correctly, but I can't figure out why. If I emulate what that Action does (writing a certain config to a `.npmrc` file), it's able to publish to NPM. I've already verified this, so hopefully it continues to work after merging this PR.

- Added back `.npmrc` with basic config from before.
- Updated `NPM Publish` Action to write auth setting to `.npmrc`.
- Removed invalid `check-latest` and unnecessary `registry-url` settings for `actions/setup-node@v1` Action.