### PR TITLE
Add note to readme about LDK commands

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -99,7 +99,7 @@ Olive Helps expects the following files when running a plugin:
 
 ### Commands
 
-We've made the following commands available to you:
+If the Node LDK package is installed globally (`npm i -g @oliveai/ldk`), the following commands are available:
 
 ```shell
 ldk build # Builds your project. Expects that you have index.js as your entry point, plugin.json, storage.json files.


### PR DESCRIPTION
Just a small tweak to the readme, but I added a note about needing to install the LDK globally for commands to be available.